### PR TITLE
Add support for servers that don't support token based authentication

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -5,14 +5,35 @@ import { SubsonicJsonResponse } from '@/types/responses/subsonicResponse'
 import { appName } from '@/utils/appName'
 import { saltWord } from '@/utils/salt'
 import { isTauri } from '@/utils/tauriTools'
+import { AuthType } from '@/types/serverConfig'
+
+
+type AuthParams =
+  | { u: string; t: string; s: string }
+  | { u: string; p: string };
+
+export function authQueryParams(username: string, password: string, authType: AuthType | null) : AuthParams {
+    if (authType == AuthType.TOKEN){
+        return {
+            u: username ?? '',
+            t: password ?? '',
+            s: saltWord,
+        }
+    }
+    else if (authType == AuthType.PASSWORD){
+        return {
+            u: username ?? '',
+            p: password ?? '',
+        }
+    }
+    throw new Error("Invalid/unspecified auth type")
+}
 
 function queryParams() {
-  const { username, password } = useAppStore.getState().data
+  const { username, password, authType } = useAppStore.getState().data
 
   return {
-    u: username ?? '',
-    t: password ?? '',
-    s: saltWord,
+    ...authQueryParams(username, password, authType),
     v: '1.16.0',
     c: appName,
     f: 'json',

--- a/src/api/pingServer.ts
+++ b/src/api/pingServer.ts
@@ -1,15 +1,14 @@
 import { fetch as tauriFetch } from '@tauri-apps/api/http'
 import { SubsonicJsonResponse } from '@/types/responses/subsonicResponse'
 import { appName } from '@/utils/appName'
-import { saltWord } from '@/utils/salt'
 import { isTauri } from '@/utils/tauriTools'
+import { authQueryParams } from './httpClient'
+import { AuthType } from '@/types/serverConfig'
 
-export async function pingServer(url: string, user: string, token: string) {
+export async function pingServer(url: string, user: string, password: string, authType: AuthType) {
   try {
     const query = {
-      u: user,
-      t: token,
-      s: saltWord,
+      ...authQueryParams(user, password, authType),
       v: '1.16.0',
       c: appName,
       f: 'json',

--- a/src/types/serverConfig.ts
+++ b/src/types/serverConfig.ts
@@ -1,3 +1,7 @@
+export enum AuthType {
+    PASSWORD,
+    TOKEN,
+}
 export interface IServerConfig {
   url: string
   username: string
@@ -5,6 +9,7 @@ export interface IServerConfig {
 }
 
 export interface IAppData extends IServerConfig {
+  authType: AuthType | null
   isServerConfigured: boolean
   osType: string
   logoutDialogState: boolean

--- a/src/utils/salt.ts
+++ b/src/utils/salt.ts
@@ -1,1 +1,5 @@
 export const saltWord = '40n50kuPl4y3r'
+
+export function toHex(s: string){
+    return s.split('').map((c) => c.charCodeAt(0).toString(16)).join('')
+}


### PR DESCRIPTION
This changes causes the login process to fall back to authenticating directly with the user's password if the token method doesn't work.

This enables the application to connect to servers that don't support token-based authentication.

For context:
I'm running a self-hosted [supysonic](https://github.com/spl0k/supysonic) as the backend and it doesn't (and won't ever) support the token-based authentication since that methods requires the server to know the user's plaintext password.