### PR TITLE
Consistently use ID3-based endpoints

### DIFF
--- a/src/app/components/command/command-menu.tsx
+++ b/src/app/components/command/command-menu.tsx
@@ -244,7 +244,7 @@ export default function CommandMenu() {
                     >
                       <ResultItem
                         coverArt={album.coverArt}
-                        title={album.title}
+                        title={album.name}
                         artist={album.artist}
                         onClick={() => handlePlayAlbum(album.id)}
                       />

--- a/src/app/components/home/preview-list.cy.tsx
+++ b/src/app/components/home/preview-list.cy.tsx
@@ -55,7 +55,7 @@ describe('PreviewList Component', () => {
 
         cy.get('@activeCarousel')
           .findByTestId('card-title')
-          .should('have.text', album.title)
+          .should('have.text', album.name)
 
         cy.get('@activeCarousel')
           .findByTestId('card-subtitle')

--- a/src/app/components/home/preview-list.tsx
+++ b/src/app/components/home/preview-list.tsx
@@ -126,7 +126,7 @@ export default function PreviewList({
                   </PreviewCard.ImageWrapper>
                   <PreviewCard.InfoWrapper>
                     <PreviewCard.Title link={ROUTES.ALBUM.PAGE(album.id)}>
-                      {album.title}
+                      {album.name}
                     </PreviewCard.Title>
                     <PreviewCard.Subtitle
                       enableLink={album.artistId !== undefined}

--- a/src/app/pages/albums/list.tsx
+++ b/src/app/pages/albums/list.tsx
@@ -196,7 +196,7 @@ export default function AlbumsList() {
               </PreviewCard.ImageWrapper>
               <PreviewCard.InfoWrapper>
                 <PreviewCard.Title link={ROUTES.ALBUM.PAGE(album.id)}>
-                  {album.title}
+                  {album.name}
                 </PreviewCard.Title>
                 <PreviewCard.Subtitle
                   enableLink={album.artistId !== undefined}

--- a/src/service/albums.ts
+++ b/src/service/albums.ts
@@ -25,7 +25,7 @@ async function getAlbumList(params: Partial<AlbumListParams> = {}) {
     genre,
   } = params
 
-  const response = await httpClient<AlbumListResponse>('/getAlbumList', {
+  const response = await httpClient<AlbumListResponse>('/getAlbumList2', {
     method: 'GET',
     query: {
       type,
@@ -39,7 +39,7 @@ async function getAlbumList(params: Partial<AlbumListParams> = {}) {
 
   return {
     albumsCount: response?.count,
-    list: response?.data.albumList.album,
+    list: response?.data.albumList2.album,
   }
 }
 
@@ -55,7 +55,7 @@ async function getOne(id: string) {
 }
 
 async function getInfo(id: string) {
-  const response = await httpClient<AlbumInfoResponse>('/getAlbumInfo', {
+  const response = await httpClient<AlbumInfoResponse>('/getAlbumInfo2', {
     method: 'GET',
     query: {
       id,

--- a/src/types/responses/album.ts
+++ b/src/types/responses/album.ts
@@ -1,4 +1,4 @@
-import { IReplayGain, ISong } from './song'
+import { ISong } from './song'
 import { SubsonicResponse } from './subsonicResponse'
 
 export interface Genre {
@@ -13,11 +13,7 @@ export interface OriginalReleaseDate {}
 
 export interface Albums {
   id: string
-  parent: string
-  isDir: boolean
-  title: string
   name: string
-  album: string
   artist: string
   year: number
   genre?: string
@@ -28,15 +24,6 @@ export interface Albums {
   starred?: string
   artistId: string
   songCount: number
-  isVideo: boolean
-  played?: string
-  bpm: number
-  comment: string
-  sortName: string
-  mediaType: string
-  musicBrainzId: string
-  genres: Genre[]
-  replayGain: IReplayGain
 }
 
 export interface SingleAlbum {
@@ -68,7 +55,7 @@ export interface AlbumList {
 }
 
 export interface AlbumListResponse
-  extends SubsonicResponse<{ albumList: AlbumList }> {}
+  extends SubsonicResponse<{ albumList2: AlbumList }> {}
 
 export interface GetAlbumResponse
   extends SubsonicResponse<{ album: SingleAlbum }> {}
@@ -79,6 +66,7 @@ export interface IArtistAlbum extends Albums {
 
 export interface IAlbumInfo {
   notes?: string
+  musicBrainzId?: string
   lastFmUrl?: string
   smallImageUrl?: string
   mediumImageUrl?: string


### PR DESCRIPTION
Background
------------
The subsonic API differentiates between organizing music by file structure vs. ID3 tags. This effectively means that there are 2 of most endpoints - one that organizes by ID3 tags and one by file structure.

Navidrome blurs this line a bit by only supporting ID3 tags and *simulating* a file structure based on them. From https://www.navidrome.org/docs/overview/ :

> Navidrome [does not support](https://www.navidrome.org/docs/faq/#can-you-add-a-browsing-by-folder-optionmode-to-navidrome) browsing by folders, but simulates it based on the tags with a structure like: `/AlbumArtist/Album/01-Song.ext`

Not only does it provide an ID3-based file structure, it shares the IDs across the different views. Taking the above example, this means that the album "Album" would have the same ID as the folder `/AlbumArtist/Album`. This makes it possible to use any ID with any API endpoint without having to worry about if the endpoint expects ID3-based IDs or file structure-based IDs.

This is a pretty smart way to do things, but isn't something that most other servers do.

The issue
----------
Previously, the albums listed on the main page would be retrieved from the `getAlbumList` endpoint (file structure based), and their `id`'s would then be passed to `getAlbum` (ID3-based) to retrieve songs and other information. Since the `id` from `getAlbumList` referred to a folder ID and `getAlbum` expects an album ID, this would return bad/no data for non-Navidrome servers.

The fix
-------
This commit changes the album listing endpoint that's used from `getAlbumList` to the ID3-based `getAlbumList2`. This ensures that the `id` property of the returned albums always refers to an ID3-based album, not a folder. This endpoint doesn't provide the exact same data, but most of it overlaps. The only required change was to use the album's `name` attribute instead of `title`.

Similarly, the `getAlbumInfo` endpoint was changed to `getAlbumInfo2`. These endpoints return the exact same data so no other changes were required.