### PR TITLE
Fix: invalidate queries on login/logout

### DIFF
--- a/src/app/components/login/form.tsx
+++ b/src/app/components/login/form.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useQueryClient } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -54,6 +55,7 @@ export function LoginForm() {
   const { saveConfig } = useAppActions()
   const navigate = useNavigate()
   const { t } = useTranslation()
+  const queryClient = useQueryClient()
 
   const form = useForm<FormData>({
     resolver: zodResolver(loginSchema),
@@ -71,6 +73,7 @@ export function LoginForm() {
     })
 
     if (status) {
+      await queryClient.invalidateQueries()
       toast.success(t('toast.server.success'))
       navigate(ROUTES.LIBRARY.HOME, { replace: true })
     } else {

--- a/src/app/components/playlist/sidebar-list.tsx
+++ b/src/app/components/playlist/sidebar-list.tsx
@@ -28,7 +28,7 @@ export function SidebarPlaylists() {
       </div>
       <div className="flex flex-col overflow-y-auto">
         <ScrollArea id="playlists" className="pr-4 pb-2">
-          {playlists && playlists.length > 0 ? (
+          {playlists !== undefined && playlists.length > 0 ? (
             <SidebarPlaylistGenerator playlists={playlists} />
           ) : (
             <span className="w-full truncate text-left px-3 pt-2 text-sm">

--- a/src/service/playlists.ts
+++ b/src/service/playlists.ts
@@ -13,7 +13,7 @@ async function getAll() {
     method: 'GET',
   })
 
-  return response?.data.playlists.playlist
+  return response?.data.playlists.playlist ?? []
 }
 
 async function getOne(id: string) {

--- a/src/store/app.store.ts
+++ b/src/store/app.store.ts
@@ -19,7 +19,7 @@ export const useAppStore = createWithEqualityFn<IAppContext>()(
             url: '',
             username: '',
             password: '',
-            authType: null,
+            authType: AuthType.TOKEN,
             logoutDialogState: false,
           },
           command: {
@@ -89,7 +89,7 @@ export const useAppStore = createWithEqualityFn<IAppContext>()(
                 state.data.url = ''
                 state.data.username = ''
                 state.data.password = ''
-                state.data.authType = null
+                state.data.authType = AuthType.TOKEN
               })
             },
             setLogoutDialogState: (value) => {


### PR DESCRIPTION
- [x] Invalidate queries on login, to clear previous user/server data.
- [x] Return an empty array if `getAllPlaylists` response is undefined
- [x] Set `AuthType.TOKEN` as default value on App State.