### PR TITLE
Add shortcuts to shuffle and repeat

### DIFF
--- a/src/app/components/header/browser-logout.tsx
+++ b/src/app/components/header/browser-logout.tsx
@@ -1,8 +1,10 @@
-import { Globe, LogOut, User } from 'lucide-react'
+import { Globe, Keyboard, LogOut, User } from 'lucide-react'
+import { useState } from 'react'
 import { Fragment } from 'react/jsx-runtime'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useTranslation } from 'react-i18next'
 
+import { ShortcutsDialog } from '@/app/components/shortcuts/dialog'
 import { Avatar, AvatarFallback } from '@/app/components/ui/avatar'
 import { Button } from '@/app/components/ui/button'
 import {
@@ -22,12 +24,19 @@ export function BrowserLogout() {
     (state) => state.actions.setLogoutDialogState,
   )
   const { t } = useTranslation()
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
 
   useHotkeys('shift+ctrl+q', () => setLogoutDialogState(true))
+  useHotkeys('mod+/', () => setShortcutsOpen((prev) => !prev))
 
   return (
     <Fragment>
       <LogoutObserver />
+
+      <ShortcutsDialog
+        open={shortcutsOpen}
+        onOpenChange={(open) => setShortcutsOpen(open)}
+      />
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -47,6 +56,12 @@ export function BrowserLogout() {
           <DropdownMenuItem disabled>
             <Globe className="mr-2 h-4 w-4" />
             <span>{url}</span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => setShortcutsOpen(true)}>
+            <Keyboard className="mr-2 h-4 w-4" />
+            <span>{t('shortcuts.modal.title')}</span>
+            <DropdownMenuShortcut>{'⌘/'}</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setLogoutDialogState(true)}>

--- a/src/app/components/player/controls.tsx
+++ b/src/app/components/player/controls.tsx
@@ -8,8 +8,10 @@ import {
   SkipForward,
 } from 'lucide-react'
 import { useEffect } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
+import { type HotkeyCallback, type Keys, useHotkeys } from 'react-hotkeys-hook'
+import { useTranslation } from 'react-i18next'
 import { Button } from '@/app/components/ui/button'
+import { SimpleTooltip } from '@/app/components/ui/simple-tooltip'
 import {
   usePlayerActions,
   usePlayerCurrentList,
@@ -28,6 +30,7 @@ interface PlayerControlsProps {
 }
 
 export function PlayerControls({ song, radio }: PlayerControlsProps) {
+  const { t } = useTranslation()
   const mediaType = usePlayerMediaType()
   const isShuffleActive = usePlayerShuffle()
   const isLoopActive = usePlayerLoop()
@@ -44,10 +47,18 @@ export function PlayerControls({ song, radio }: PlayerControlsProps) {
   } = usePlayerActions()
   const currentList = usePlayerCurrentList()
 
-  useHotkeys('space', () => togglePlayPause(), {
-    preventDefault: true,
-    enabled: currentList.length > 0,
-  })
+  useAudioHotkeys('space', togglePlayPause)
+  useAudioHotkeys('left', playPrevSong)
+  useAudioHotkeys('right', playNextSong)
+  useAudioHotkeys('s', toggleShuffle)
+  useAudioHotkeys('r', toggleLoop)
+
+  function useAudioHotkeys(keys: Keys, callback: HotkeyCallback) {
+    useHotkeys(keys, callback, {
+      preventDefault: true,
+      enabled: currentList.length > 0,
+    })
+  }
 
   useEffect(() => {
     manageMediaSession.setHandlers({
@@ -57,73 +68,93 @@ export function PlayerControls({ song, radio }: PlayerControlsProps) {
     })
   }, [playNextSong, playPrevSong, togglePlayPause])
 
+  const shuffleTooltip = isShuffleActive
+    ? t('player.tooltips.shuffle.disable')
+    : t('player.tooltips.shuffle.enable')
+  const playTooltip = isPlaying
+    ? t('player.tooltips.pause')
+    : t('player.tooltips.play')
+  const repeatTooltip = isLoopActive
+    ? t('player.tooltips.repeat.disable')
+    : t('player.tooltips.repeat.enable')
+
   return (
     <div className="flex w-full gap-1 justify-center items-center mb-1">
       {mediaType === 'song' && (
-        <Button
-          variant="ghost"
-          className={clsx(
-            'relative rounded-full w-10 h-10 p-3',
-            isShuffleActive && 'player-button-active',
-          )}
-          disabled={!song || isPlayingOneSong() || !hasNextSong()}
-          onClick={toggleShuffle}
-          data-testid="player-button-shuffle"
-        >
-          <Shuffle
-            className={clsx('w-10 h-10', isShuffleActive && 'text-primary')}
-          />
-        </Button>
+        <SimpleTooltip text={shuffleTooltip}>
+          <Button
+            variant="ghost"
+            className={clsx(
+              'relative rounded-full w-10 h-10 p-3',
+              isShuffleActive && 'player-button-active',
+            )}
+            disabled={!song || isPlayingOneSong() || !hasNextSong()}
+            onClick={toggleShuffle}
+            data-testid="player-button-shuffle"
+          >
+            <Shuffle
+              className={clsx('w-10 h-10', isShuffleActive && 'text-primary')}
+            />
+          </Button>
+        </SimpleTooltip>
       )}
 
-      <Button
-        variant="ghost"
-        className="rounded-full w-10 h-10 p-3"
-        disabled={(!song && !radio) || !hasPrevSong()}
-        onClick={playPrevSong}
-        data-testid="player-button-prev"
-      >
-        <SkipBack className="w-10 h-10 fill-secondary-foreground" />
-      </Button>
-
-      <Button
-        className="rounded-full w-10 h-10 p-3"
-        disabled={!song && !radio}
-        onClick={togglePlayPause}
-        data-testid={`player-button-${isPlaying ? 'pause' : 'play'}`}
-      >
-        {isPlaying ? (
-          <Pause className="w-10 h-10 fill-slate-50 text-slate-50" />
-        ) : (
-          <Play className="w-10 h-10 fill-slate-50 text-slate-50" />
-        )}
-      </Button>
-
-      <Button
-        variant="ghost"
-        className="rounded-full w-10 h-10 p-3"
-        disabled={(!song && !radio) || !hasNextSong()}
-        onClick={playNextSong}
-        data-testid="player-button-next"
-      >
-        <SkipForward className="w-10 h-10 fill-secondary-foreground" />
-      </Button>
-
-      {mediaType === 'song' && (
+      <SimpleTooltip text={t('player.tooltips.previous')}>
         <Button
           variant="ghost"
-          className={clsx(
-            'relative rounded-full w-10 h-10 p-3',
-            isLoopActive && 'player-button-active',
-          )}
-          disabled={!song}
-          onClick={toggleLoop}
-          data-testid="player-button-loop"
+          className="rounded-full w-10 h-10 p-3"
+          disabled={(!song && !radio) || !hasPrevSong()}
+          onClick={playPrevSong}
+          data-testid="player-button-prev"
         >
-          <Repeat
-            className={clsx('w-10 h-10', isLoopActive && 'text-primary')}
-          />
+          <SkipBack className="w-10 h-10 fill-secondary-foreground" />
         </Button>
+      </SimpleTooltip>
+
+      <SimpleTooltip text={playTooltip}>
+        <Button
+          className="rounded-full w-10 h-10 p-3"
+          disabled={!song && !radio}
+          onClick={togglePlayPause}
+          data-testid={`player-button-${isPlaying ? 'pause' : 'play'}`}
+        >
+          {isPlaying ? (
+            <Pause className="w-10 h-10 fill-slate-50 text-slate-50" />
+          ) : (
+            <Play className="w-10 h-10 fill-slate-50 text-slate-50" />
+          )}
+        </Button>
+      </SimpleTooltip>
+
+      <SimpleTooltip text={t('player.tooltips.next')}>
+        <Button
+          variant="ghost"
+          className="rounded-full w-10 h-10 p-3"
+          disabled={(!song && !radio) || !hasNextSong()}
+          onClick={playNextSong}
+          data-testid="player-button-next"
+        >
+          <SkipForward className="w-10 h-10 fill-secondary-foreground" />
+        </Button>
+      </SimpleTooltip>
+
+      {mediaType === 'song' && (
+        <SimpleTooltip text={repeatTooltip}>
+          <Button
+            variant="ghost"
+            className={clsx(
+              'relative rounded-full w-10 h-10 p-3',
+              isLoopActive && 'player-button-active',
+            )}
+            disabled={!song}
+            onClick={toggleLoop}
+            data-testid="player-button-loop"
+          >
+            <Repeat
+              className={clsx('w-10 h-10', isLoopActive && 'text-primary')}
+            />
+          </Button>
+        </SimpleTooltip>
       )}
     </div>
   )

--- a/src/app/components/player/like-button.tsx
+++ b/src/app/components/player/like-button.tsx
@@ -1,31 +1,46 @@
 import clsx from 'clsx'
 import { Heart } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { Button } from '@/app/components/ui/button'
-import { usePlayerActions, usePlayerSongStarred } from '@/store/player.store'
+import { SimpleTooltip } from '@/app/components/ui/simple-tooltip'
+import {
+  usePlayerActions,
+  usePlayerSongStarred,
+  usePlayerStore,
+} from '@/store/player.store'
 
 interface PlayerLikeButtonProps {
   disabled: boolean
 }
 
 export function PlayerLikeButton({ disabled }: PlayerLikeButtonProps) {
+  const { t } = useTranslation()
   const isSongStarred = usePlayerSongStarred()
+  const { title: song, artist } = usePlayerStore(
+    (state) => state.songlist.currentSong,
+  )
   const { starCurrentSong } = usePlayerActions()
 
+  const translationLabel = `player.tooltips.${isSongStarred ? 'dislike' : 'like'}`
+  const likeTooltip = t(translationLabel, { song, artist })
+
   return (
-    <Button
-      variant="ghost"
-      className="rounded-full w-10 h-10 p-3"
-      disabled={disabled}
-      onClick={starCurrentSong}
-      data-testid="player-like-button"
-    >
-      <Heart
-        className={clsx(
-          'w-5 h-5',
-          isSongStarred && 'text-red-500 fill-red-500',
-        )}
-        data-testid="player-like-icon"
-      />
-    </Button>
+    <SimpleTooltip text={likeTooltip}>
+      <Button
+        variant="ghost"
+        className="rounded-full w-10 h-10 p-3"
+        disabled={disabled}
+        onClick={starCurrentSong}
+        data-testid="player-like-button"
+      >
+        <Heart
+          className={clsx(
+            'w-5 h-5',
+            isSongStarred && 'text-red-500 fill-red-500',
+          )}
+          data-testid="player-like-icon"
+        />
+      </Button>
+    </SimpleTooltip>
   )
 }

--- a/src/app/components/player/song-list-button.tsx
+++ b/src/app/components/player/song-list-button.tsx
@@ -1,7 +1,9 @@
 import { ListVideo } from 'lucide-react'
 import { Fragment } from 'react/jsx-runtime'
+import { useTranslation } from 'react-i18next'
 import { QueuePage } from '@/app/components/queue/page'
 import { Button } from '@/app/components/ui/button'
+import { SimpleTooltip } from '@/app/components/ui/simple-tooltip'
 import { usePlayerActions, useQueueDrawerState } from '@/store/player.store'
 
 interface PlayerSongListButtonProps {
@@ -9,19 +11,22 @@ interface PlayerSongListButtonProps {
 }
 
 export function PlayerSongListButton({ disabled }: PlayerSongListButtonProps) {
+  const { t } = useTranslation()
   const queueDrawerState = useQueueDrawerState()
   const { setQueueDrawerState } = usePlayerActions()
 
   return (
     <Fragment>
-      <Button
-        variant="ghost"
-        className="rounded-full w-10 h-10 p-2"
-        disabled={disabled}
-        onClick={() => setQueueDrawerState(!queueDrawerState)}
-      >
-        <ListVideo className="w-4 h-4" />
-      </Button>
+      <SimpleTooltip text={t('queue.title')}>
+        <Button
+          variant="ghost"
+          className="rounded-full w-10 h-10 p-2"
+          disabled={disabled}
+          onClick={() => setQueueDrawerState(!queueDrawerState)}
+        >
+          <ListVideo className="w-4 h-4" />
+        </Button>
+      </SimpleTooltip>
 
       <QueuePage />
     </Fragment>

--- a/src/app/components/player/volume.tsx
+++ b/src/app/components/player/volume.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { Volume, Volume1, Volume2 } from 'lucide-react'
+import { VolumeX, Volume1, Volume2 } from 'lucide-react'
 import { RefObject, useEffect } from 'react'
 import { Slider } from '@/app/components/ui/slider'
 import { usePlayerVolume } from '@/store/player.store'
@@ -23,7 +23,7 @@ export function PlayerVolume({ disabled, audioRef }: PlayerVolumeProps) {
       <div className={clsx(disabled && 'opacity-50')}>
         {volume >= 50 && <Volume2 className="w-4 h-4" />}
         {volume > 0 && volume < 50 && <Volume1 className="w-4 h-4" />}
-        {volume === 0 && <Volume className="w-4 h-4" />}
+        {volume === 0 && <VolumeX className="w-4 h-4" />}
       </div>
       <Slider
         defaultValue={[100]}

--- a/src/app/components/shortcuts/dialog.tsx
+++ b/src/app/components/shortcuts/dialog.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next'
+import { Keyboard } from '@/app/components/command/keyboard-key'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/app/components/ui/dialog'
+import { playbackShortcuts } from '@/shortcuts/playback'
+import { ShortcutsGroup } from './group'
+
+interface ShortcutsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ShortcutsDialog({ open, onOpenChange }: ShortcutsDialogProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="p-0 gap-0">
+        <DialogHeader className="p-6 border-b-[1px] border-b-border mb-0">
+          <DialogTitle>{t('shortcuts.modal.title')}</DialogTitle>
+          <div className="flex gap-1 text-sm text-muted-foreground">
+            <p>{t('shortcuts.modal.description.first')}</p>{' '}
+            <Keyboard
+              text="⌘"
+              className="ml-3 relative w-5 top-0 text-base pl-[4px] pt-[1px]"
+            />{' '}
+            <Keyboard text="/" className="relative w-5 top-0" />
+            <p className="-ml-1">{t('shortcuts.modal.description.last')}</p>
+          </div>
+        </DialogHeader>
+        <div className="px-6 pt-4 pb-6 max-h-[400px] overflow-y-auto space-y-4">
+          <ShortcutsGroup
+            title={t('shortcuts.playback.label')}
+            shortcuts={playbackShortcuts}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/components/shortcuts/group.tsx
+++ b/src/app/components/shortcuts/group.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next'
+import { Keyboard } from '@/app/components/command/keyboard-key'
+import { IShortcut } from '@/types/shortcuts'
+
+interface ShortcutsGroupProps {
+  title: string
+  shortcuts: IShortcut[]
+}
+
+export function ShortcutsGroup({ title, shortcuts }: ShortcutsGroupProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-3">
+      <span className="font-medium block">{title}</span>
+      <div className="space-y-2">
+        {shortcuts.map(({ label, shortcuts: keys }) => (
+          <div
+            key={label}
+            className="flex justify-between relative text-muted-foreground"
+          >
+            <p className="text-sm">{t(label)}</p>
+            <div className="flex gap-1">
+              {keys.map((key) => (
+                <Keyboard text={key} className="top-0 relative" key={key} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -347,6 +347,23 @@ export const english = {
       title: 'Queue',
       clear: 'Clear queue',
     },
+    shortcuts: {
+      modal: {
+        title: 'Keyboard Shortcuts',
+        description: {
+          first: 'Press',
+          last: 'to toggle this modal.',
+        },
+      },
+      playback: {
+        label: 'Playback',
+        play: 'Play / Pause',
+        shuffle: 'Shuffle',
+        repeat: 'Repeat',
+        previous: 'Skip to previous',
+        next: 'Skip to next',
+      },
+    },
     dayjs: {
       relativeTime: {
         future: 'in %s',

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -238,6 +238,22 @@ export const english = {
     player: {
       noSongPlaying: 'No song playing',
       noRadioPlaying: 'No radio playing',
+      tooltips: {
+        shuffle: {
+          enable: 'Enable shuffle',
+          disable: 'Disable shuffle',
+        },
+        previous: 'Previous',
+        play: 'Play',
+        pause: 'Pause',
+        next: 'Next',
+        repeat: {
+          enable: 'Enable repeat',
+          disable: 'Disable repeat',
+        },
+        like: 'Like {{song}} by {{artist}}',
+        dislike: 'Remove like from {{song}} by {{artist}}',
+      },
     },
     options: {
       playNext: 'Play next',

--- a/src/i18n/languages/pt-BR.ts
+++ b/src/i18n/languages/pt-BR.ts
@@ -241,6 +241,22 @@ export const brazilianPortuguese = {
     player: {
       noSongPlaying: 'Nenhuma música tocando',
       noRadioPlaying: 'Nenhum rádio tocando',
+      tooltips: {
+        shuffle: {
+          enable: 'Ativar aleatório',
+          disable: 'Desativar aleatório',
+        },
+        previous: 'Voltar',
+        play: 'Play',
+        pause: 'Pausar',
+        next: 'Avançar',
+        repeat: {
+          enable: 'Repetir',
+          disable: 'Não repetir',
+        },
+        like: 'Curtir {{song}} por {{artist}}',
+        dislike: 'Remover curtida de {{song}} por {{artist}}',
+      },
     },
     options: {
       playNext: 'Tocar a seguir',

--- a/src/i18n/languages/pt-BR.ts
+++ b/src/i18n/languages/pt-BR.ts
@@ -352,6 +352,23 @@ export const brazilianPortuguese = {
       title: 'Fila de reprodução',
       clear: 'Limpar fila',
     },
+    shortcuts: {
+      modal: {
+        title: 'Atalhos de teclado',
+        description: {
+          first: 'Pressione',
+          last: 'para abrir/fechar esta janela.',
+        },
+      },
+      playback: {
+        label: 'Reprodução',
+        play: 'Play / Pausar',
+        shuffle: 'Ordem aleatória',
+        repeat: 'Repetir',
+        previous: 'Voltar à faixa anterior',
+        next: 'Pular para a próxima faixa',
+      },
+    },
     dayjs: {
       relativeTime: {
         future: 'em %s',

--- a/src/shortcuts/playback.ts
+++ b/src/shortcuts/playback.ts
@@ -1,0 +1,24 @@
+import { IShortcut } from '@/types/shortcuts'
+
+export const playbackShortcuts: IShortcut[] = [
+  {
+    label: 'shortcuts.playback.play',
+    shortcuts: ['Space'],
+  },
+  {
+    label: 'shortcuts.playback.shuffle',
+    shortcuts: ['S'],
+  },
+  {
+    label: 'shortcuts.playback.repeat',
+    shortcuts: ['R'],
+  },
+  {
+    label: 'shortcuts.playback.previous',
+    shortcuts: ['←'],
+  },
+  {
+    label: 'shortcuts.playback.next',
+    shortcuts: ['→'],
+  },
+]

--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -213,6 +213,13 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
             },
             toggleShuffle: () => {
               const { isShuffleActive } = get().playerState
+              const { currentList, currentSongIndex } = get().songlist
+
+              const listLength = currentList.length
+              const isPlayingOneOrLess = listLength <= 1
+              const isPlayingLastSong = currentSongIndex === listLength - 1
+
+              if (isPlayingOneOrLess || isPlayingLastSong) return
 
               if (isShuffleActive) {
                 const currentSongId = get().songlist.currentSong.id

--- a/src/types/shortcuts.ts
+++ b/src/types/shortcuts.ts
@@ -1,0 +1,4 @@
+export interface IShortcut {
+  label: string
+  shortcuts: string[]
+}


### PR DESCRIPTION
- [x] Shortcut for Shuffle (S)
- [x] Shortcut for Repeat (R)
- [x] Add tooltips to player buttons
- [x] Change volume icon to `VolumeX` when volume equals to `0`
- [x] Update `toggleShuffle` function on store, to check if it's possible to active shuffle, otherwise, do nothing.
- [x] Add a modal to show all keyboard shortcuts (`mod+/`)