### PR TITLE
Avoid sending undefined parameters to the server

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -47,7 +47,9 @@ function getUrl(path: string, options?: Record<string, string>) {
 
   if (options) {
     Object.keys(options).forEach((key) => {
-      params.append(key, options[key])
+      if (options[key] !== undefined) {
+        params.append(key, options[key])
+      }
     })
   }
 


### PR DESCRIPTION
Previously, clicking the "Home" tab would send a request like:
```
GET /rest/getAlbumList2?[...]&type=recent&size=16&offset=0&fromYear=undefined&toYear=undefined&genre=undefined
```

Now, it sends:
```
GET /rest/getAlbumList2?[...]&type=recent&size=16&offset=0
```