### PR TITLE
Use server default for streaming quality

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -41,14 +41,14 @@ function queryParams() {
   }
 }
 
-function getUrl(path: string, options?: Record<string, string>) {
+function getUrl(path: string, options?: Record<string, string | undefined>) {
   const serverUrl = useAppStore.getState().data.url
   const params = new URLSearchParams(queryParams())
 
   if (options) {
     Object.keys(options).forEach((key) => {
       if (options[key] !== undefined) {
-        params.append(key, options[key])
+        params.append(key, options[key]!)
       }
     })
   }
@@ -149,7 +149,11 @@ export function getCoverArtUrl(
   })
 }
 
-export function getSongStreamUrl(id: string, maxBitRate = '0', format = 'raw') {
+export function getSongStreamUrl(
+  id: string,
+  maxBitRate?: string,
+  format?: string,
+) {
   return getUrl('stream', {
     id,
     maxBitRate,


### PR DESCRIPTION
Some servers allow configuring a default streaming profile that they will use unless the client specifies otherwise.

Instead of sending a hardcoded max bitrate of `0` and format of `raw`, this change omits any unspecified values, allowing the server to decide the default.