### PR TITLE
fix: use http protocol on windows

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,7 +52,8 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "dangerousUseHttpScheme": true
     },
     "bundle": {
       "active": true,


### PR DESCRIPTION
This PR changes the protocol for Windows, preventing content from being mixed when making HTTP requests, as Tauri loads the bundle on HTTPS by default. This change will only affect Windows.

Windows: `http://tauri.localhost/`
macOS and Linux: `tauri://localhost/`