### PR TITLE
fix: change the line height of the album header title

### DIFF
--- a/src/app/components/album/image-header.tsx
+++ b/src/app/components/album/image-header.tsx
@@ -118,14 +118,14 @@ export default function ImageHeader({
         </div>
 
         <div className="flex flex-col justify-end z-10">
-          <p className="text-xs 2xl:text-sm mb-1 2xl:mb-2 font-medium drop-shadow-md">
+          <p className="text-xs 2xl:text-sm font-medium drop-shadow-md">
             {type}
           </p>
           <h1
             className={clsx(
               'scroll-m-20 font-bold tracking-tight antialiased drop-shadow-md line-clamp-2',
               getTextSizeClass(title),
-              subtitle ? 'mb-1 2xl:mb-2' : 'mb-1',
+              subtitle && 'mb-1',
             )}
           >
             {title}

--- a/src/app/components/fallbacks/album-fallbacks.tsx
+++ b/src/app/components/fallbacks/album-fallbacks.tsx
@@ -10,8 +10,9 @@ export function AlbumHeaderFallback() {
     <div className="w-full px-8 py-6 bg-muted-foreground flex gap-4 bg-gradient-to-b from-white/50 to-white/50 dark:from-black/50 dark:to-black/50">
       <Skeleton className="rounded shadow-lg w-[200px] h-[200px] min-w-[200px] min-h-[200px] 2xl:w-[250px] 2xl:h-[250px] 2xl:min-w-[250px] 2xl:min-h-[250px] aspect-square" />
       <div className="flex flex-col justify-end">
-        <Skeleton className="h-[20px] w-16 mb-2" />
-        <Skeleton className="h-12 w-[260px] mb-2" />
+        <Skeleton className="h-[20px] w-16 mb-4" />
+        <Skeleton className="h-12 w-[260px] mb-4" />
+        <Skeleton className="h-5 w-[340px] mb-1" />
 
         <div className="flex gap-2 mt-2">
           <Skeleton className="h-[22px] w-12 rounded-full" />

--- a/src/utils/getTextSizeClass.ts
+++ b/src/utils/getTextSizeClass.ts
@@ -1,7 +1,7 @@
 export function getTextSizeClass(text: string) {
   if (text.length > 40) {
-    return 'text-3xl 2xl:text-5xl leading-[1.1] 2xl:leading-[1.2]'
+    return 'text-3xl 2xl:text-5xl leading-[2.25rem] 2xl:leading-[3.75rem]'
   }
 
-  return 'text-4xl 2xl:text-6xl leading-[1.05] 2xl:leading-[1.1]'
+  return 'text-4xl 2xl:text-6xl leading-[2.75rem] 2xl:leading-[4.75rem]'
 }


### PR DESCRIPTION
Adjust the line height to ensure low-hanging characters aren’t cut off.