### PR TITLE
Add Support For Synced Lyrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-hotkeys-hook": "^4.5.0",
     "react-i18next": "^14.1.2",
     "react-lazy-load-image-component": "^1.6.0",
+    "react-lrc": "^3.2.1",
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.23.1",
     "react-toastify": "^10.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       react-lazy-load-image-component:
         specifier: ^1.6.0
         version: 1.6.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-lrc:
+        specifier: ^3.2.1
+        version: 3.2.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-markdown:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.3.12)(react@18.2.0)
@@ -2132,6 +2135,9 @@ packages:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
     engines: {node: '>=8'}
 
+  clrc@3.1.4:
+    resolution: {integrity: sha512-lNWVrD2u+PRB9sQimJOjpAUdqRNsgQgx2c+oI00Uqxt4p2Aiusx0MlPLNjXs5t0mqQqz7UlyzqTIHVPIAjAGLg==}
+
   clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
     engines: {node: '>=6'}
@@ -3584,6 +3590,12 @@ packages:
       react: ^15.x.x || ^16.x.x || ^17.x.x || ^18.x.x
       react-dom: ^15.x.x || ^16.x.x || ^17.x.x || ^18.x.x
 
+  react-lrc@3.2.1:
+    resolution: {integrity: sha512-CRmjtFjjL6Y4RLGSgBxpP7RD9rAJqLLJeRKbC7TYzBFxWFQysOzc2j1dtjGc8rOsOMz6Pfeh4352qUh97dBhZA==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   react-markdown@9.0.1:
     resolution: {integrity: sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==}
     peerDependencies:
@@ -3699,6 +3711,9 @@ packages:
 
   request-progress@3.0.0:
     resolution: {integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==}
+
+  resize-observer-polyfill@1.5.1:
+    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -6133,6 +6148,8 @@ snapshots:
       slice-ansi: 3.0.0
       string-width: 4.2.3
 
+  clrc@3.1.4: {}
+
   clsx@2.0.0: {}
 
   clsx@2.1.1: {}
@@ -7986,6 +8003,13 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
+  react-lrc@3.2.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      clrc: 3.1.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      resize-observer-polyfill: 1.5.1
+
   react-markdown@9.0.1(@types/react@18.3.12)(react@18.2.0):
     dependencies:
       '@types/hast': 3.0.4
@@ -8141,6 +8165,8 @@ snapshots:
   request-progress@3.0.0:
     dependencies:
       throttleit: 1.0.1
+
+  resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
 

--- a/src/app/components/fullscreen/lyrics.tsx
+++ b/src/app/components/fullscreen/lyrics.tsx
@@ -34,16 +34,18 @@ export function LyricsTab() {
   const loadingLyrics = t('fullscreen.loadingLyrics')
 
   if (isLoading) {
-    return <p className="leading-10 drop-shadow-lg">{loadingLyrics}</p>
+    return <UnsyncedLyrics lyrics={{ value: loadingLyrics}}/>
   }
   else if (lyrics && lyrics.value) {
     return (areLyricsSynced(lyrics)) ? <SyncedLyrics lyrics={lyrics}/> : <UnsyncedLyrics lyrics={lyrics}/>
   }
   else {
-    return <p className="leading-10 drop-shadow-lg">{noLyricsFound}</p>
+    return <UnsyncedLyrics lyrics={{ value: noLyricsFound }}/>
   }
 
 }
+
+
 
 function SyncedLyrics({ lyrics }: LyricProps) {
 
@@ -63,7 +65,7 @@ function SyncedLyrics({ lyrics }: LyricProps) {
   return (
     <>
       <div
-        className="h-full overflow-y-auto text-center font-semibold text-3xl px-2 scroll-smooth lrc-box"
+        className="h-full overflow-y-auto text-center font-semibold text-2xl 2xl:text-3xl px-2 scroll-smooth lrc-box"
       >
           <Lrc
             lrc={lyrics.value!}
@@ -71,7 +73,7 @@ function SyncedLyrics({ lyrics }: LyricProps) {
             currentMillisecond={progress}
             className="max-h-full"
             lineRenderer={({ active, line: { content } }) => (
-              <p style={{ opacity: active ? 1 : 0.7 }} className="leading-20 drop-shadow-lg my-3 transition-opacity">{content}</p>
+              <p style={{ opacity: active ? 1 : 0.7 }} className="leading-20 drop-shadow-lg my-3 duration-500 transition-opacity">{content}</p>
             )}
           />
       </div>
@@ -101,7 +103,7 @@ function UnsyncedLyrics({ lyrics }: LyricProps) {
 
   return (
     <ScrollArea
-      className="h-full overflow-y-auto text-center font-semibold text-xl 2xl:text-2xl px-2 scroll-smooth"
+      className="h-full overflow-y-auto text-center font-semibold text-2xl 2xl:text-3xl px-2 scroll-smooth"
       ref={lyricsBoxRef}
     >
       {

--- a/src/app/components/fullscreen/lyrics.tsx
+++ b/src/app/components/fullscreen/lyrics.tsx
@@ -62,6 +62,12 @@ function SyncedLyrics({ lyrics }: LyricProps) {
     setProgress(newProgress)
   }, 50)
 
+  const skipToTime = (timeMs: number) => {
+    if (!!playerRef) {
+      playerRef!.currentTime = (timeMs / 1000)
+    }
+  }
+
   return (
     <>
       <div
@@ -72,8 +78,8 @@ function SyncedLyrics({ lyrics }: LyricProps) {
             recoverAutoScrollInterval={1500}
             currentMillisecond={progress}
             className="max-h-full"
-            lineRenderer={({ active, line: { content } }) => (
-              <p style={{ opacity: active ? 1 : 0.7 }} className="leading-20 drop-shadow-lg my-3 duration-500 transition-opacity">{content}</p>
+            lineRenderer={({ active, line }) => (
+              <p style={{ opacity: active ? 1 : 0.7 }} onClick={() => skipToTime(line.startMillisecond)} className="leading-20 drop-shadow-lg my-3 cursor-pointer duration-500 transition-opacity">{line.content}</p>
             )}
           />
       </div>

--- a/src/app/components/fullscreen/lyrics.tsx
+++ b/src/app/components/fullscreen/lyrics.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { act, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   ScrollArea,

--- a/src/app/components/fullscreen/lyrics.tsx
+++ b/src/app/components/fullscreen/lyrics.tsx
@@ -23,7 +23,7 @@ export function LyricsTab() {
   const { data: lyrics, isLoading } = useQuery({
     queryKey: ['get-lyrics', artist, title],
     queryFn: () =>
-      subsonic.songs.getLyrics({
+      subsonic.lyrics.getLyrics({
         artist,
         title,
       }),

--- a/src/app/components/fullscreen/lyrics.tsx
+++ b/src/app/components/fullscreen/lyrics.tsx
@@ -1,15 +1,20 @@
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useRef } from 'react'
+import { act, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   ScrollArea,
   scrollAreaViewportSelector,
 } from '@/app/components/ui/scroll-area'
 import { subsonic } from '@/service/subsonic'
-import { usePlayerSonglist } from '@/store/player.store'
+import { usePlayerSonglist, usePlayerProgress, usePlayerRef } from '@/store/player.store'
+import { Lrc, useRecoverAutoScrollImmediately } from 'react-lrc';
+import { ILyric } from '@/types/responses/song'
+
+interface LyricProps {
+  lyrics: ILyric
+}
 
 export function LyricsTab() {
-  const lyricsBoxRef = useRef<HTMLDivElement>(null)
   const { currentSong } = usePlayerSonglist()
   const { t } = useTranslation()
 
@@ -24,6 +29,61 @@ export function LyricsTab() {
       }),
   })
 
+
+  const noLyricsFound = t('fullscreen.noLyrics')
+  const loadingLyrics = t('fullscreen.loadingLyrics')
+
+  if (isLoading) {
+    return <p className="leading-10 drop-shadow-lg">{loadingLyrics}</p>
+  }
+  else if (lyrics && lyrics.value) {
+    return <AutoLyrics lyrics={lyrics}></AutoLyrics>
+  }
+  else {
+    return <p className="leading-10 drop-shadow-lg">{noLyricsFound}</p>
+  }
+
+}
+
+// Chooses between synced and unsynced based on the contents of the lyric text
+function AutoLyrics({ lyrics }: LyricProps) {
+  // TODO: better method of detecting lrc files
+  return (lyrics!.value?.trim().includes("[00:")) ? <SyncedLyrics lyrics={lyrics}/> : <UnsyncedLyrics lyrics={lyrics}/>
+}
+
+function SyncedLyrics({ lyrics }: LyricProps) {
+
+  const playerRef = usePlayerRef()
+  const [progress, setProgress] = useState(0)
+
+  setTimeout(() => setProgress((playerRef?.currentTime || 0) * 1000), 50)
+
+  return (
+    <>
+      <div
+        className="h-full overflow-y-auto text-center font-semibold text-3xl 2xl:text-2xl px-2 scroll-smooth lrc-box"
+      >
+          <Lrc
+            lrc={lyrics.value!}
+            recoverAutoScrollInterval={1500}
+            currentMillisecond={progress}
+            className="max-h-full"
+            lineRenderer={({ active, line: { content } }) => (
+              <p style={{ opacity: active ? 1 : 0.7 }} className="leading-20 drop-shadow-lg my-3 transition-opacity">{content}</p>
+            )}
+          />
+      </div>
+    </>
+  )
+}
+
+function UnsyncedLyrics({ lyrics }: LyricProps) {
+
+  const { currentSong } = usePlayerSonglist()
+  const lyricsBoxRef = useRef<HTMLDivElement>(null)
+
+  let lines = lyrics.value!.split('\n')
+
   useEffect(() => {
     if (lyricsBoxRef.current) {
       const scrollArea = lyricsBoxRef.current.querySelector(
@@ -37,29 +97,18 @@ export function LyricsTab() {
     }
   }, [currentSong])
 
-  const noLyricsFound = t('fullscreen.noLyrics')
-  const loadingLyrics = t('fullscreen.loadingLyrics')
-
-  let lines = [noLyricsFound]
-
-  if (lyrics && lyrics.value) {
-    lines = lyrics.value.split('\n')
-  }
-
   return (
     <ScrollArea
       className="h-full overflow-y-auto text-center font-semibold text-xl 2xl:text-2xl px-2 scroll-smooth"
       ref={lyricsBoxRef}
     >
-      {isLoading && (
-        <p className="leading-10 drop-shadow-lg">{loadingLyrics}</p>
-      )}
-      {!isLoading &&
+      {
         lines.map((line, index) => (
           <p key={index} className="leading-10 drop-shadow-lg">
             {line}
           </p>
-        ))}
+        ))
+      }
     </ScrollArea>
   )
 }

--- a/src/service/lyrics.ts
+++ b/src/service/lyrics.ts
@@ -49,7 +49,7 @@ async function getLyricsFromLRCLib({ artist, title }: GetLyricsData) {
             return {
                 artist,
                 title,
-                value: response?.syncedLyrics || response?.plainLyrics || ""
+                value: formatLyrics(response?.syncedLyrics) || formatLyrics(response?.plainLyrics) || ""
             }
         }
     }
@@ -60,6 +60,10 @@ async function getLyricsFromLRCLib({ artist, title }: GetLyricsData) {
         title,
         value: ""
     }
+}
+
+function formatLyrics(lyrics: string) {
+    return lyrics.trim().replaceAll("\r\n", "\n")
 }
 
 export const lyrics = {

--- a/src/service/lyrics.ts
+++ b/src/service/lyrics.ts
@@ -1,0 +1,69 @@
+import { httpClient } from "@/api/httpClient"
+import { LyricsResponse } from "@/types/responses/song"
+
+
+
+interface GetLyricsData {
+    artist: string
+    title: string
+} 
+
+interface LRCLibResponse {
+    id: number,
+    trackName: string,
+    artistName: string,
+    plainLyrics: string,
+    syncedLyrics: string
+} 
+
+async function getLyrics(getLyricsData: GetLyricsData) {
+    const response = await httpClient<LyricsResponse>('/getLyrics', {
+      method: 'GET',
+      query: {
+        artist: getLyricsData.artist,
+        title: getLyricsData.title,
+      },
+    })
+  
+    if (!response || !response?.data.lyrics || !response.data.lyrics.value) {
+        return getLyricsFromLRCLib(getLyricsData)
+    }
+
+    return response?.data.lyrics
+}
+
+
+async function getLyricsFromLRCLib({ artist, title }: GetLyricsData) {
+
+    try {
+        const params = new URLSearchParams({
+            artist_name: artist,
+            track_name: title,
+        })
+    
+        const request = await fetch('https://lrclib.net/api/get?' + params.toString())
+        const response: LRCLibResponse = await request.json()
+
+    
+        if (!!response) {
+            return {
+                artist,
+                title,
+                value: response?.syncedLyrics || response?.plainLyrics || ""
+            }
+        }
+    }
+    catch {}
+
+    return {
+        artist,
+        title,
+        value: ""
+    }
+}
+
+export const lyrics = {
+    getLyrics,
+    getLyricsFromLRCLib
+}
+  

--- a/src/service/songs.ts
+++ b/src/service/songs.ts
@@ -1,7 +1,6 @@
 import { httpClient } from '@/api/httpClient'
 import {
   GetSongResponse,
-  LyricsResponse,
   RandomSongsResponse,
   TopSongsResponse,
 } from '@/types/responses/song'

--- a/src/service/songs.ts
+++ b/src/service/songs.ts
@@ -44,22 +44,6 @@ async function getTopSongs(artistName: string) {
   return response?.data.topSongs.song
 }
 
-interface GetLyricsData {
-  artist: string
-  title: string
-}
-
-async function getLyrics({ artist, title }: GetLyricsData) {
-  const response = await httpClient<LyricsResponse>('/getLyrics', {
-    method: 'GET',
-    query: {
-      artist,
-      title,
-    },
-  })
-
-  return response?.data.lyrics
-}
 
 async function getAllSongs(songCount: number) {
   const response = await search.get({
@@ -88,6 +72,5 @@ export const songs = {
   getAllSongs,
   getRandomSongs,
   getTopSongs,
-  getLyrics,
   getSong,
 }

--- a/src/service/subsonic.ts
+++ b/src/service/subsonic.ts
@@ -2,6 +2,7 @@ import { albums } from './albums'
 import { artists } from './artists'
 import { genres } from './genres'
 import { library } from './library'
+import { lyrics } from './lyrics'
 import { ping } from './ping'
 import { playlists } from './playlists'
 import { radios } from './radios'
@@ -22,4 +23,5 @@ export const subsonic = {
   search,
   songs,
   star,
+  lyrics
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2021",
     "useDefineForClassFields": true,
     "lib": [
-      "ES2020",
+      "ES2021",
       "DOM",
       "DOM.Iterable"
     ],


### PR DESCRIPTION
Aonsoku will now detect synced (LRC) lyric data and render it based on the time value of the audio player (accurate to 50ms).
Additionally, if no lyrics are found, it will try and fetch lyrics from [lrclib.net](https://github.com/tranxuanthang/lrclib) and use those instead.

![image](https://github.com/user-attachments/assets/06b0ffe2-68c3-48d6-923e-280083951a01)

In the future, it would be great to also support other external lyric providers and allow the user to search and select lyrics from them.