### PR TITLE
fix: Use byte length for search check

### DIFF
--- a/src/app/components/command/command-menu.tsx
+++ b/src/app/components/command/command-menu.tsx
@@ -30,6 +30,7 @@ import { usePlaylists } from '@/store/playlists.store'
 import { useTheme } from '@/store/theme.store'
 import { ISimilarArtist } from '@/types/responses/artist'
 import { ScanStatus } from '@/types/responses/library'
+import { byteLength } from '@/utils/byteLength'
 import { convertMinutesToMs } from '@/utils/convertSecondsToTime'
 import dateTime from '@/utils/dateTime'
 import { queryKeys } from '@/utils/queryKeys'
@@ -39,7 +40,6 @@ import {
   CustomHeaderLink,
 } from './command-group'
 import { CustomCommandItem } from './command-item'
-import { byteLength } from '@/utils/byteLength'
 
 type CommandPages = 'HOME' | 'GOTO' | 'THEME' | 'PLAYLISTS' | 'SERVER'
 
@@ -69,7 +69,9 @@ export default function CommandMenu() {
   const activePage = pages[pages.length - 1]
   const isHome = activePage === 'HOME'
 
-  const enableQuery = Boolean(byteLength(query) >= 3 && activePage !== 'PLAYLISTS')
+  const enableQuery = Boolean(
+    byteLength(query) >= 3 && activePage !== 'PLAYLISTS',
+  )
 
   const { data: searchResult } = useQuery({
     queryKey: [queryKeys.search, query],

--- a/src/app/components/command/command-menu.tsx
+++ b/src/app/components/command/command-menu.tsx
@@ -39,6 +39,7 @@ import {
   CustomHeaderLink,
 } from './command-group'
 import { CustomCommandItem } from './command-item'
+import { byteLength } from '@/utils/byteLength'
 
 type CommandPages = 'HOME' | 'GOTO' | 'THEME' | 'PLAYLISTS' | 'SERVER'
 
@@ -68,7 +69,7 @@ export default function CommandMenu() {
   const activePage = pages[pages.length - 1]
   const isHome = activePage === 'HOME'
 
-  const enableQuery = Boolean(query.length >= 3 && activePage !== 'PLAYLISTS')
+  const enableQuery = Boolean(byteLength(query) >= 3 && activePage !== 'PLAYLISTS')
 
   const { data: searchResult } = useQuery({
     queryKey: [queryKeys.search, query],

--- a/src/utils/byteLength.ts
+++ b/src/utils/byteLength.ts
@@ -1,0 +1,10 @@
+export function byteLength(str: String) {
+    var s = str.length;
+    for (var i=str.length-1; i>=0; i--) {
+      var code = str.charCodeAt(i);
+      if (code > 0x7f && code <= 0x7ff) s++;
+      else if (code > 0x7ff && code <= 0xffff) s+=2;
+      if (code >= 0xDC00 && code <= 0xDFFF) i--;
+    }
+    return s;
+}

--- a/src/utils/byteLength.ts
+++ b/src/utils/byteLength.ts
@@ -1,10 +1,10 @@
-export function byteLength(str: String) {
-    var s = str.length;
-    for (var i=str.length-1; i>=0; i--) {
-      var code = str.charCodeAt(i);
-      if (code > 0x7f && code <= 0x7ff) s++;
-      else if (code > 0x7ff && code <= 0xffff) s+=2;
-      if (code >= 0xDC00 && code <= 0xDFFF) i--;
-    }
-    return s;
+export function byteLength(str: string) {
+  let s = str.length
+  for (let i = str.length - 1; i >= 0; i--) {
+    const code = str.charCodeAt(i)
+    if (code > 0x7f && code <= 0x7ff) s++
+    else if (code > 0x7ff && code <= 0xffff) s += 2
+    if (code >= 0xdc00 && code <= 0xdfff) i--
+  }
+  return s
 }


### PR DESCRIPTION
Closes #117 

Very simple fix, just checks the number of bytes instead of string length when searching. 1-byte english characters will have the same behavior, but when testing with random chinese characters the search triggers when only typing one symbol.