### PR TITLE
Discord RPC Support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -68,6 +68,7 @@ version = "0.8.1"
 dependencies = [
  "cocoa 0.25.0",
  "dirs",
+ "discord-sdk",
  "futures-util",
  "objc",
  "rand 0.8.5",
@@ -85,12 +86,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "app_dirs2"
+version = "2.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e7b35733e3a8c1ccb90385088dd5b6eaa61325cb4d1ad56e683b5224ff352e"
+dependencies = [
+ "jni",
+ "ndk-context",
+ "winapi",
+ "xdg",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -643,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +735,31 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "discord-sdk"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de8f587263d1c13696fb47e885ba81ad3c07412069f66850e7730413f40af2ef"
+dependencies = [
+ "anyhow",
+ "app_dirs2",
+ "async-trait",
+ "bitflags 2.5.0",
+ "crossbeam-channel",
+ "data-encoding",
+ "num-traits",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "thiserror 2.0.3",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "winreg",
 ]
 
 [[package]]
@@ -4186,7 +4241,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5042,6 +5109,12 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "zeroize"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ dirs = "5.0.1"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2.0.1"
 tauri-plugin-shell = "2"
+discord-sdk = "=0.4.0"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 cocoa = "0.25.0"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,9 +2,9 @@ use futures_util::StreamExt;
 use reqwest::{header::ACCEPT, Client, Url};
 
 use dirs::download_dir;
-use std::{fs::File, io::Write, path::PathBuf};
+use std::{fs::File, io::Write, path::PathBuf, time::{Duration, SystemTime}};
 
-use crate::{progress::Progress, utils::get_filename};
+use crate::{discord::rpc::{self, discord}, progress::Progress, utils::get_filename};
 
 #[tauri::command]
 pub async fn download_file(
@@ -45,5 +45,27 @@ pub async fn download_file(
     }
 
     progress.emit_finished(&app_handle);
+    Ok(())
+}
+
+
+#[tauri::command]
+pub async fn update_player_status(
+    track_name: String,
+    album_name: String,
+    artist: String,
+    start_time: u64,
+    end_time: u64
+) -> Result<(), String> {
+
+    use rpc::CURRENT_STATUS;
+
+    unsafe {
+        CURRENT_STATUS.track_name = track_name;
+        CURRENT_STATUS.artist = artist;
+        CURRENT_STATUS.start_time = SystemTime::from(SystemTime::UNIX_EPOCH + Duration::from_millis(start_time));
+        CURRENT_STATUS.end_time = SystemTime::from(SystemTime::UNIX_EPOCH + Duration::from_millis(end_time));
+    }
+
     Ok(())
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -63,6 +63,7 @@ pub async fn update_player_status(
     unsafe {
         CURRENT_STATUS.track_name = track_name;
         CURRENT_STATUS.artist = artist;
+        CURRENT_STATUS.album_name = album_name;
         CURRENT_STATUS.start_time = SystemTime::from(SystemTime::UNIX_EPOCH + Duration::from_millis(start_time));
         CURRENT_STATUS.end_time = SystemTime::from(SystemTime::UNIX_EPOCH + Duration::from_millis(end_time));
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -55,7 +55,8 @@ pub async fn update_player_status(
     album_name: String,
     artist: String,
     start_time: u64,
-    end_time: u64
+    end_time: u64,
+    is_paused: bool
 ) -> Result<(), String> {
 
     use rpc::CURRENT_STATUS;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -67,6 +67,7 @@ pub async fn update_player_status(
         CURRENT_STATUS.album_name = album_name;
         CURRENT_STATUS.start_time = SystemTime::from(SystemTime::UNIX_EPOCH + Duration::from_millis(start_time));
         CURRENT_STATUS.end_time = SystemTime::from(SystemTime::UNIX_EPOCH + Duration::from_millis(end_time));
+        CURRENT_STATUS.is_paused = is_paused;
     }
 
     Ok(())

--- a/src-tauri/src/discord/mod.rs
+++ b/src-tauri/src/discord/mod.rs
@@ -1,0 +1,1 @@
+pub mod rpc;

--- a/src-tauri/src/discord/rpc.rs
+++ b/src-tauri/src/discord/rpc.rs
@@ -72,6 +72,11 @@ pub async fn update_activity_status() {
             None => return,
         };
     
+        if (CURRENT_STATUS.is_paused) {
+            let _ = client.discord.clear_activity().await;
+            return;
+        }
+
         let _ = client.discord.update_activity(current_activity).await; // Discard the result to _
     }
 

--- a/src-tauri/src/discord/rpc.rs
+++ b/src-tauri/src/discord/rpc.rs
@@ -68,9 +68,13 @@ pub async fn make_client() {
 pub async fn update_activity_status() {
 
     unsafe {
+
+        let artist = CURRENT_STATUS.artist.to_owned();
+        let album_name = CURRENT_STATUS.album_name.to_owned();
+
         let current_activity = discord::activity::ActivityBuilder::default()
             .details(CURRENT_STATUS.track_name.to_owned())
-            .state(CURRENT_STATUS.artist.to_owned())
+            .state(format!("{artist} • {album_name}"))
             .kind(discord_sdk::activity::ActivityKind::Listening)
             .start_timestamp(CURRENT_STATUS.start_time)
             .end_timestamp(CURRENT_STATUS.end_time);

--- a/src-tauri/src/discord/rpc.rs
+++ b/src-tauri/src/discord/rpc.rs
@@ -61,6 +61,10 @@ pub async fn update_activity_status() {
         let current_activity = discord::activity::ActivityBuilder::default()
             .details(CURRENT_STATUS.track_name.to_owned())
             .state(format!("{artist} • {album_name}"))
+            .assets(
+                discord::activity::Assets::default()
+                    .large("https://github.com/victoralvesf/aonsoku/blob/main/public/icon_shadow.png?raw=true".to_owned(), Some("Aonsoku".to_owned()))
+            )
             .kind(discord_sdk::activity::ActivityKind::Listening)
             .start_timestamp(CURRENT_STATUS.start_time)
             .end_timestamp(CURRENT_STATUS.end_time);

--- a/src-tauri/src/discord/rpc.rs
+++ b/src-tauri/src/discord/rpc.rs
@@ -17,7 +17,8 @@ pub static mut CURRENT_STATUS: PlayerStatus = PlayerStatus {
     album_name: String::new(),
     artist: String::new(),
     start_time: SystemTime::UNIX_EPOCH,
-    end_time: SystemTime::UNIX_EPOCH
+    end_time: SystemTime::UNIX_EPOCH,
+    is_paused: true
 };
 
 pub async fn make_client() {

--- a/src-tauri/src/discord/rpc.rs
+++ b/src-tauri/src/discord/rpc.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, ptr, time::{Duration, SystemTime}};
+use std::{ptr, time::{Duration, SystemTime}};
 
 pub use discord_sdk as discord;
 
@@ -6,8 +6,6 @@ use crate::playerstatus::PlayerStatus;
 
 pub struct Client {
     pub discord: discord::Discord,
-    pub user: discord::user::User,
-    pub wheel: discord::wheel::Wheel,
 }
 
 
@@ -37,22 +35,10 @@ pub async fn make_client() {
         }
     };
 
-
-    user.0.changed().await.unwrap();
-
-    let user = match &*user.0.borrow() {
-        discord::wheel::UserState::Connected(user) => user.clone(),
-        discord::wheel::UserState::Disconnected(_err) => {
-            return; // Something went wrong, ignore it (most likely the user has their activities set to private)
-        },
-    };
-
     unsafe {
         CURRENT_CLIENT = Some(
             Client {
                 discord,
-                user,
-                wheel,
             }
         );
     }

--- a/src-tauri/src/discord/rpc.rs
+++ b/src-tauri/src/discord/rpc.rs
@@ -61,10 +61,6 @@ pub async fn update_activity_status() {
         let current_activity = discord::activity::ActivityBuilder::default()
             .details(CURRENT_STATUS.track_name.to_owned())
             .state(format!("{artist} • {album_name}"))
-            .assets(
-                discord::activity::Assets::default()
-                    .large("https://github.com/victoralvesf/aonsoku/blob/main/public/icon_shadow.png?raw=true".to_owned(), Some("Aonsoku".to_owned()))
-            )
             .kind(discord_sdk::activity::ActivityKind::Listening)
             .start_timestamp(CURRENT_STATUS.start_time)
             .end_timestamp(CURRENT_STATUS.end_time);

--- a/src-tauri/src/discord/rpc.rs
+++ b/src-tauri/src/discord/rpc.rs
@@ -1,0 +1,87 @@
+use std::{any::Any, ptr, time::{Duration, SystemTime}};
+
+pub use discord_sdk as discord;
+
+use crate::playerstatus::PlayerStatus;
+
+pub struct Client {
+    pub discord: discord::Discord,
+    pub user: discord::user::User,
+    pub wheel: discord::wheel::Wheel,
+}
+
+
+pub const APP_ID: discord::AppId = 1332231131336282125; // App ID Listed As Aonsoku, You May Change It If You Wish
+
+pub static mut CURRENT_CLIENT: Option<Client> = None;
+pub static mut CURRENT_STATUS: PlayerStatus = PlayerStatus {
+    track_name: String::new(),
+    album_name: String::new(),
+    artist: String::new(),
+    start_time: SystemTime::UNIX_EPOCH,
+    end_time: SystemTime::UNIX_EPOCH
+};
+
+pub async fn make_client() {
+
+    let (wheel, handler) = discord::wheel::Wheel::new(Box::new(|_err| {
+        // Something went wrong, ignore it (most likely the user doesn't have discord)
+    }));
+
+    let mut user = wheel.user();
+
+    let discord = match discord::Discord::new(discord::DiscordApp::PlainId(APP_ID), discord::Subscriptions::ACTIVITY, Box::new(handler)) {
+        Ok(dc) => dc,
+        Err(_err) => {
+            return; // Something went wrong, ignore it (most likely the user doesn't have discord)
+        }
+    };
+
+
+    user.0.changed().await.unwrap();
+
+    let user = match &*user.0.borrow() {
+        discord::wheel::UserState::Connected(user) => user.clone(),
+        discord::wheel::UserState::Disconnected(_err) => {
+            return; // Something went wrong, ignore it (most likely the user has their activities set to private)
+        },
+    };
+
+    unsafe {
+        CURRENT_CLIENT = Some(
+            Client {
+                discord,
+                user,
+                wheel,
+            }
+        );
+    }
+
+    loop {
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+        update_activity_status().await;
+    }
+
+
+}
+
+pub async fn update_activity_status() {
+
+    unsafe {
+        let current_activity = discord::activity::ActivityBuilder::default()
+            .details(CURRENT_STATUS.track_name.to_owned())
+            .state(CURRENT_STATUS.artist.to_owned())
+            .kind(discord_sdk::activity::ActivityKind::Listening)
+            .start_timestamp(CURRENT_STATUS.start_time)
+            .end_timestamp(CURRENT_STATUS.end_time);
+    
+    
+        let client = match &CURRENT_CLIENT {
+            Some(c) => c,
+            None => return,
+        };
+    
+        let _ = client.discord.update_activity(current_activity).await; // Discard the result to _
+    }
+
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -35,7 +35,7 @@ async fn main() {
     // Spawn the discord RPC handler on another thread
     use discord::rpc::make_client;
 
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     tokio::task::spawn(make_client());
 
     builder

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -34,6 +34,8 @@ async fn main() {
 
     // Spawn the discord RPC handler on another thread
     use discord::rpc::make_client;
+
+    #[cfg(target_os = "windows")]
     tokio::task::spawn(make_client());
 
     builder

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,9 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+
+use std::{ptr::null, thread};
+
 #[cfg(not(target_os = "linux"))]
 use tauri::Manager;
 
@@ -15,15 +18,23 @@ extern crate objc;
 #[cfg(target_os = "macos")]
 mod mac;
 
+mod discord;
+mod playerstatus;
+
 mod commands;
 mod progress;
 mod utils;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let builder = tauri::Builder::default();
 
     #[cfg(target_os = "macos")]
     let builder = builder.plugin(mac::window::init());
+
+    // Spawn the discord RPC handler on another thread
+    use discord::rpc::make_client;
+    tokio::task::spawn(make_client());
 
     builder
         .setup(|_app| {
@@ -54,6 +65,7 @@ fn main() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_os::init())
         .invoke_handler(tauri::generate_handler![commands::download_file])
+        .invoke_handler(tauri::generate_handler![commands::update_player_status])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/playerstatus.rs
+++ b/src-tauri/src/playerstatus.rs
@@ -7,5 +7,6 @@ pub struct PlayerStatus {
     pub album_name: String,
     pub artist: String,
     pub end_time: SystemTime,
-    pub start_time: SystemTime
+    pub start_time: SystemTime,
+    pub is_paused: bool
 }

--- a/src-tauri/src/playerstatus.rs
+++ b/src-tauri/src/playerstatus.rs
@@ -1,0 +1,11 @@
+use std::time::SystemTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PlayerStatus {
+    pub track_name: String,
+    pub album_name: String,
+    pub artist: String,
+    pub end_time: SystemTime,
+    pub start_time: SystemTime
+}

--- a/src/service/rpc.ts
+++ b/src/service/rpc.ts
@@ -1,11 +1,13 @@
 import { invoke } from '@tauri-apps/api/core'
-import { ISong } from '@/types/responses/song'
 import { isTauri } from '@/utils/tauriTools'
+import { IPlayerContext } from '@/types/playerContext'
 
-async function send(song: ISong, audio: HTMLAudioElement | null) {
+async function send(playerStore: IPlayerContext, audio: HTMLAudioElement | null) {
   if (!isTauri() || !audio) {
     return
   }
+
+  let song = playerStore.songlist.currentSong;
 
   const statusData = {
     trackName: song.title,
@@ -17,7 +19,7 @@ async function send(song: ISong, audio: HTMLAudioElement | null) {
         (audio!.currentTime || 0) * 1000 +
         (audio!.duration || 0) * 1000,
     ),
-    isPaused: audio.paused
+    isPaused: !playerStore.playerState.isPlaying
   }
 
   await invoke('update_player_status', statusData)

--- a/src/service/rpc.ts
+++ b/src/service/rpc.ts
@@ -1,13 +1,16 @@
 import { invoke } from '@tauri-apps/api/core'
-import { isTauri } from '@/utils/tauriTools'
 import { IPlayerContext } from '@/types/playerContext'
+import { isTauri } from '@/utils/tauriTools'
 
-async function send(playerStore: IPlayerContext, audio: HTMLAudioElement | null) {
+async function send(
+  playerStore: IPlayerContext,
+  audio: HTMLAudioElement | null,
+) {
   if (!isTauri() || !audio) {
     return
   }
 
-  let song = playerStore.songlist.currentSong;
+  const song = playerStore.songlist.currentSong
 
   const statusData = {
     trackName: song.title,
@@ -19,7 +22,7 @@ async function send(playerStore: IPlayerContext, audio: HTMLAudioElement | null)
         (audio!.currentTime || 0) * 1000 +
         (audio!.duration || 0) * 1000,
     ),
-    isPaused: !playerStore.playerState.isPlaying
+    isPaused: !playerStore.playerState.isPlaying,
   }
 
   await invoke('update_player_status', statusData)

--- a/src/service/rpc.ts
+++ b/src/service/rpc.ts
@@ -1,23 +1,27 @@
-import { ISong } from "@/types/responses/song"
-import { isTauri } from "@/utils/tauriTools"
-import { invoke } from "@tauri-apps/api/core"
+import { invoke } from '@tauri-apps/api/core'
+import { ISong } from '@/types/responses/song'
+import { isTauri } from '@/utils/tauriTools'
 
-async function send(song: ISong, audio: HTMLAudioElement|null) {
-    
-    if (!isTauri() || !audio) { return; }
+async function send(song: ISong, audio: HTMLAudioElement | null) {
+  if (!isTauri() || !audio) {
+    return
+  }
 
-    const statusData = { 
-        trackName: song.title,
-        albumName: song.album,
-        artist: song.artist,
-        startTime: Math.floor(Date.now() - ((audio!.currentTime || 0) * 1000)),
-        endTime: Math.floor((Date.now() - ((audio!.currentTime || 0) * 1000)) + ((audio!.duration || 0) * 1000))
-    }
+  const statusData = {
+    trackName: song.title,
+    albumName: song.album,
+    artist: song.artist,
+    startTime: Math.floor(Date.now() - (audio!.currentTime || 0) * 1000),
+    endTime: Math.floor(
+      Date.now() -
+        (audio!.currentTime || 0) * 1000 +
+        (audio!.duration || 0) * 1000,
+    ),
+  }
 
-    await invoke("update_player_status", statusData)
+  await invoke('update_player_status', statusData)
 }
 
 export const rpc = {
-    send,
-} 
-  
+  send,
+}

--- a/src/service/rpc.ts
+++ b/src/service/rpc.ts
@@ -17,6 +17,7 @@ async function send(song: ISong, audio: HTMLAudioElement | null) {
         (audio!.currentTime || 0) * 1000 +
         (audio!.duration || 0) * 1000,
     ),
+    isPaused: audio.paused
   }
 
   await invoke('update_player_status', statusData)

--- a/src/service/rpc.ts
+++ b/src/service/rpc.ts
@@ -1,0 +1,23 @@
+import { ISong } from "@/types/responses/song"
+import { isTauri } from "@/utils/tauriTools"
+import { invoke } from "@tauri-apps/api/core"
+
+async function send(song: ISong, audio: HTMLAudioElement|null) {
+    
+    if (!isTauri() || !audio) { return; }
+
+    const statusData = { 
+        trackName: song.title,
+        albumName: song.album,
+        artist: song.artist,
+        startTime: Math.floor(Date.now() - ((audio!.currentTime || 0) * 1000)),
+        endTime: Math.floor((Date.now() - ((audio!.currentTime || 0) * 1000)) + ((audio!.duration || 0) * 1000))
+    }
+
+    await invoke("update_player_status", statusData)
+}
+
+export const rpc = {
+    send,
+} 
+  

--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -587,14 +587,22 @@ usePlayerStore.subscribe(
     const { currentList } = playerStore.songlist
     const { progress } = playerStore.playerProgress
 
-    rpc.send(
-      playerStore.songlist.currentSong,
-      playerStore.playerState.audioPlayerRef,
-    )
-
     if (currentList.length === 0 && progress > 0) {
       playerStore.actions.resetProgress()
     }
+  },
+)
+
+// For RPC
+usePlayerStore.subscribe(
+  (state) => [state.playerProgress.progress, state.playerState.isPlaying],
+  () => {
+    const playerStore = usePlayerStore.getState()
+
+    rpc.send(
+      playerStore,
+      playerStore.playerState.audioPlayerRef,
+    )
   },
 )
 

--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -6,12 +6,12 @@ import { devtools, persist, subscribeWithSelector } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
 import { shallow } from 'zustand/shallow'
 import { createWithEqualityFn } from 'zustand/traditional'
+import { rpc } from '@/service/rpc'
 import { subsonic } from '@/service/subsonic'
 import { IPlayerContext, LoopState } from '@/types/playerContext'
 import { ISong } from '@/types/responses/song'
 import { areSongListsEqual } from '@/utils/compareSongLists'
 import { addNextSongList, shuffleSongList } from '@/utils/songListFunctions'
-import { rpc } from '@/service/rpc'
 
 export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
   subscribeWithSelector(
@@ -587,7 +587,10 @@ usePlayerStore.subscribe(
     const { currentList } = playerStore.songlist
     const { progress } = playerStore.playerProgress
 
-    rpc.send(playerStore.songlist.currentSong, playerStore.playerState.audioPlayerRef);
+    rpc.send(
+      playerStore.songlist.currentSong,
+      playerStore.playerState.audioPlayerRef,
+    )
 
     if (currentList.length === 0 && progress > 0) {
       playerStore.actions.resetProgress()

--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -11,6 +11,7 @@ import { IPlayerContext, LoopState } from '@/types/playerContext'
 import { ISong } from '@/types/responses/song'
 import { areSongListsEqual } from '@/utils/compareSongLists'
 import { addNextSongList, shuffleSongList } from '@/utils/songListFunctions'
+import { rpc } from '@/service/rpc'
 
 export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
   subscribeWithSelector(
@@ -585,6 +586,8 @@ usePlayerStore.subscribe(
 
     const { currentList } = playerStore.songlist
     const { progress } = playerStore.playerProgress
+
+    rpc.send(playerStore.songlist.currentSong, playerStore.playerState.audioPlayerRef);
 
     if (currentList.length === 0 && progress > 0) {
       playerStore.actions.resetProgress()

--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -599,10 +599,7 @@ usePlayerStore.subscribe(
   () => {
     const playerStore = usePlayerStore.getState()
 
-    rpc.send(
-      playerStore,
-      playerStore.playerState.audioPlayerRef,
-    )
+    rpc.send(playerStore, playerStore.playerState.audioPlayerRef)
   },
 )
 


### PR DESCRIPTION
Adds support for Discord rich presence (#106)

![image](https://github.com/user-attachments/assets/c26f6640-36e8-4b46-a39b-5c165625a6f0)

# Implementation
- Written in rust and updated with tauri commands.
- I have included an app ID that shows up as "Aonsoku", but you can easily change it if you want.
- It is able to handle edge cases like discord not being installed.
- The status is updated every second.
- I have tested for memory leaks and haven't found any.

# Limitations
- Album art won't be displayed because Discord requires a public-facing URL and most subsonic servers aren't exposed to the open internet for security reasons.
- I have not tested it on macOS or linux, so for now I have only enabled the feature on windows.
- Discord will continue increasing the time value of it's progress bar when the user pauses, this is because discord wants a start and stop time rather than a progress time, the issue will fix itself when the user resumes.