### PR TITLE
Fix crash removing songs from queue

### DIFF
--- a/src/app/components/queue/song-list.tsx
+++ b/src/app/components/queue/song-list.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/app/components/ui/button'
 import { DataTableList } from '@/app/components/ui/data-table-list'
+import { DialogTitle } from '@/app/components/ui/dialog'
 import { Separator } from '@/app/components/ui/separator'
 import { queueColumns } from '@/app/tables/queue-columns'
 import {
@@ -30,6 +31,7 @@ export function QueueSongList() {
 
   return (
     <div className="flex flex-1 flex-col h-full min-w-[300px]">
+      <DialogTitle className="sr-only">{t('queue.title')}</DialogTitle>
       <div className="flex items-center justify-between h-8 mb-2">
         <div className="flex gap-2 h-6 items-center text-muted-foreground">
           <p className="text-foreground">{t('queue.title')}</p>

--- a/src/app/components/table/queue-actions.tsx
+++ b/src/app/components/table/queue-actions.tsx
@@ -15,7 +15,11 @@ export function QueueActions({ row }: { row: Row<ISong> }) {
     <Button
       variant="ghost"
       className="w-8 h-8 p-1 rounded-full hover:bg-background hover:border hover:border-border hover:shadow-sm"
-      onClick={handleRemoveSongFromQueue}
+      onClick={(e) => {
+        e.stopPropagation()
+        handleRemoveSongFromQueue()
+      }}
+      onDoubleClick={(e) => e.stopPropagation()}
     >
       <XIcon className="w-5 h-5" />
     </Button>

--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -482,15 +482,31 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
               )
             },
             removeSongFromQueue: (id) => {
-              const { currentList, originalList, shuffledList } = get().songlist
+              const {
+                currentList,
+                originalList,
+                shuffledList,
+                currentSongIndex,
+                originalSongIndex,
+              } = get().songlist
 
+              // Get the removed song index to adjust the current one.
+              const removedSongIndex = currentList.findIndex(
+                (song) => song.id === id,
+              )
               const newCurrentList = currentList.filter(
                 (song) => song.id !== id,
               )
 
+              // Clear player state if list is empty
               if (newCurrentList.length === 0) {
                 get().actions.clearPlayerState()
                 return
+              }
+
+              // In case of removing current song, resets the progress
+              if (removedSongIndex === currentSongIndex) {
+                get().actions.resetProgress()
               }
 
               const newOriginalList = originalList.filter(
@@ -500,10 +516,29 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
                 (song) => song.id !== id,
               )
 
+              // Update index to fit new current list
+              const updatedCurrentIndex = Math.min(
+                currentSongIndex -
+                  (removedSongIndex < currentSongIndex ? 1 : 0),
+                newCurrentList.length - 1,
+              )
+
+              // Update original index
+              const removedOriginalIndex = originalList.findIndex(
+                (song) => song.id === id,
+              )
+              const updatedOriginalIndex = Math.min(
+                originalSongIndex -
+                  (removedOriginalIndex < originalSongIndex ? 1 : 0),
+                newOriginalList.length - 1,
+              )
+
               set((state) => {
                 state.songlist.currentList = newCurrentList
                 state.songlist.originalList = newOriginalList
                 state.songlist.shuffledList = newShuffledList
+                state.songlist.currentSongIndex = updatedCurrentIndex
+                state.songlist.originalSongIndex = updatedOriginalIndex
               })
             },
             setQueueDrawerState: (status) => {


### PR DESCRIPTION
- [x] Add screen reader only title for queue page
- [x] Stop playing the song if double clicking remove song from queue button
- [x] Fixed removeSongFromQueue function, to stop crashing the app after removing single songs.

___

Closes #131 