### PR TITLE
fix: enable tauri bundleMediaFramework

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,6 +6,11 @@
     "devUrl": "http://localhost:1420"
   },
   "bundle": {
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": true
+      }
+    },
     "active": true,
     "category": "Music",
     "createUpdaterArtifacts": true,


### PR DESCRIPTION
Without bundling GStreamer the AppImage version hangs on Arch Linux with the following message.

```
GStreamer element autoaudiosink not found. Please install it
```