### PR TITLE
implement new privacy settings page

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,5 +106,11 @@
     "tailwindcss": "^3.4.3",
     "typescript": "^5.0.2",
     "vite": "^5.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "cypress",
+      "esbuild"
+    ]
   }
 }

--- a/src/app/components/settings/options.tsx
+++ b/src/app/components/settings/options.tsx
@@ -1,4 +1,10 @@
-import { FileText, Globe, Headphones, Paintbrush } from 'lucide-react'
+import {
+  EarthLock,
+  FileText,
+  Globe,
+  Headphones,
+  Paintbrush,
+} from 'lucide-react'
 import { ComponentType } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -10,7 +16,12 @@ import {
 } from '@/app/components/ui/sidebar'
 import { useAppSettings } from '@/store/app.store'
 
-export type SettingsOptions = 'appearance' | 'language' | 'audio' | 'content'
+export type SettingsOptions =
+  | 'appearance'
+  | 'language'
+  | 'audio'
+  | 'content'
+  | 'privacy'
 
 interface OptionsData {
   id: SettingsOptions
@@ -22,6 +33,7 @@ const options: OptionsData[] = [
   { id: 'language', icon: Globe },
   { id: 'audio', icon: Headphones },
   { id: 'content', icon: FileText },
+  { id: 'privacy', icon: EarthLock },
 ]
 
 export function SettingsOptions() {

--- a/src/app/components/settings/pages/index.tsx
+++ b/src/app/components/settings/pages/index.tsx
@@ -3,12 +3,14 @@ import { Appearance } from './appearance'
 import { Audio } from './audio'
 import { Content } from './content'
 import { Language } from './language'
+import { Privacy } from './privacy'
 
 const pages = {
   appearance: <Appearance />,
   audio: <Audio />,
   language: <Language />,
   content: <Content />,
+  privacy: <Privacy />,
 }
 
 export function Pages() {

--- a/src/app/components/settings/pages/privacy/index.tsx
+++ b/src/app/components/settings/pages/privacy/index.tsx
@@ -1,0 +1,9 @@
+import { Services } from './services'
+
+export function Privacy() {
+  return (
+    <div className="space-y-4">
+      <Services />
+    </div>
+  )
+}

--- a/src/app/components/settings/pages/privacy/services.tsx
+++ b/src/app/components/settings/pages/privacy/services.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next'
+import {
+  Content,
+  ContentItem,
+  ContentItemForm,
+  ContentItemTitle,
+  ContentSeparator,
+  Header,
+  HeaderTitle,
+  HeaderDescription,
+  Root,
+} from '@/app/components/settings/section'
+import { Switch } from '@/app/components/ui/switch'
+import { usePrivacySettings } from '@/store/player.store'
+
+export function Services() {
+  const { t } = useTranslation()
+  const { lrcLibEnabled, setLrcLibEnabled } = usePrivacySettings()
+
+  return (
+    <Root>
+      <Header>
+        <HeaderTitle>{t('settings.privacy.services.group')}</HeaderTitle>
+        <HeaderDescription>
+          {t('settings.privacy.services.description')}
+        </HeaderDescription>
+      </Header>
+      <Content>
+        <ContentItem>
+          <ContentItemTitle info={t('settings.privacy.services.lrclib.info')}>
+            {t('settings.privacy.services.lrclib.label')}
+          </ContentItemTitle>
+          <ContentItemForm>
+            <Switch
+              checked={lrcLibEnabled}
+              onCheckedChange={setLrcLibEnabled}
+            />
+          </ContentItemForm>
+        </ContentItem>
+      </Content>
+      <ContentSeparator />
+    </Root>
+  )
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -505,7 +505,8 @@
       "appearance": "Erscheinungsbild",
       "language": "Sprache & Region",
       "audio": "Player & Audio",
-      "content": "Inhalte"
+      "content": "Inhalte",
+      "privacy": "Privatsphäre und Sicherheit"
     },
     "audio": {
       "replayGain": {
@@ -530,6 +531,16 @@
         },
         "group": "Liedtexte",
         "description": "Liedtext-Einstellungen anpassen."
+      }
+    },
+    "privacy": {
+      "services": {
+        "group": "Externe Dienste",
+        "description": "Legt fest welche Dienste Aonsoku verwenden kann",
+        "lrclib": {
+          "info": "LRCLib wird für Liedtexte verwendet.",
+          "label": "LRCLib"
+        }
       }
     },
     "content": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -479,7 +479,8 @@
       "appearance": "Appearance",
       "language": "Language & region",
       "audio": "Player & audio",
-      "content": "Content"
+      "content": "Content",
+      "privacy": "Privacy & Security"
     },
     "appearance": {
       "general": {
@@ -513,6 +514,16 @@
         "preferSynced": {
           "label": "Prefer synced lyrics",
           "info": "When enabled, synced lyrics will be prioritized over unsynced lyrics."
+        }
+      }
+    },
+    "privacy": {
+      "services": {
+        "group": "External Services",
+        "description": "Control which external services Aonsoku can reach out to.",
+        "lrclib": {
+          "info": "LRCLib is used for lyrics",
+          "label": "LRCLib"
         }
       }
     },

--- a/src/service/lyrics.ts
+++ b/src/service/lyrics.ts
@@ -53,7 +53,17 @@ async function getLyrics(getLyricsData: GetLyricsData) {
 }
 
 async function getLyricsFromLRCLib(getLyricsData: GetLyricsData) {
+  const { lrcLibEnabled } = usePlayerStore.getState().settings.privacy
+
   const { artist, title, album, duration } = getLyricsData
+
+  if (!lrcLibEnabled) {
+    return {
+      artist,
+      title,
+      value: '',
+    }
+  }
 
   try {
     const params = new URLSearchParams({

--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -41,6 +41,14 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
             progress: 0,
           },
           settings: {
+            privacy: {
+              lrcLibEnabled: true,
+              setLrcLibEnabled(value) {
+                set((state) => {
+                  state.settings.privacy.lrcLibEnabled = value
+                })
+              },
+            },
             volume: {
               min: 0,
               max: 100,
@@ -462,7 +470,10 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
 
               const { id, starred } = get().songlist.currentSong
               const isSongStarred = typeof starred === 'string'
-              await subsonic.star.handleStarItem({ id, starred: isSongStarred })
+              await subsonic.star.handleStarItem({
+                id,
+                starred: isSongStarred,
+              })
 
               const songList = [...currentList]
               songList[currentSongIndex] = {
@@ -670,6 +681,9 @@ export const useReplayGainActions = () =>
 
 export const useFullscreenPlayerSettings = () =>
   usePlayerStore((state) => state.settings.fullscreen)
+
+export const usePrivacySettings = () =>
+  usePlayerStore((state) => state.settings.privacy)
 
 export const useLyricsSettings = () =>
   usePlayerStore((state) => state.settings.lyrics)

--- a/src/types/playerContext.ts
+++ b/src/types/playerContext.ts
@@ -73,11 +73,17 @@ interface ILyrics {
   setPreferSyncedLyrics: (value: boolean) => void
 }
 
+export interface IPrivacySettings {
+  lrcLibEnabled: boolean
+  setLrcLibEnabled: (value: boolean) => void
+}
+
 export interface IPlayerSettings {
   volume: IVolumeSettings
   fullscreen: IFullscreen
   lyrics: ILyrics
   replayGain: IReplayGain
+  privacy: IPrivacySettings
 }
 
 export interface IPlayerActions {


### PR DESCRIPTION
This PR adds a new settings page for privacy settings, such as disabling calling to external APIs.

I also included a prettierrc that is closest to what i saw the current code style to be, since it was pretty frustrating to remember to not hit my format key.
I hope its okay that i included it in this PR, if not i can amend the current commit and add it in a seperate PR.