### PR TITLE
Add Podman Quadlet to README.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ services:
       - 8080:8080
 ```
 
+* Podman Quadlet
+```ini
+[Unit]
+Description=Aonsoku Container
+
+[Container]
+ContainerName=aonsoku
+Image=ghcr.io/victoralvesf/aonsoku:latest
+PublishPort=8080:8080
+AutoUpdate=registry
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=multi-user.target default.target
+```
+
 <details>
   <summary>Environment Variables</summary>
   </br>


### PR DESCRIPTION
I'm using Podman Quadlets on my Fedora Server and thought it could be a nice copy-paste addition to the README.

  * Podman Quadlet
  ```ini
  [Unit]
  Description=Aonsoku Container
  
  [Container]
  ContainerName=aonsoku
  Image=ghcr.io/victoralvesf/aonsoku:latest
  PublishPort=8080:8080
  AutoUpdate=registry
  
  [Service]
  Restart=always
  
  [Install]
  WantedBy=multi-user.target default.target
  ```