### PR TITLE
use the opensubsonic getLyricsBySongId to retrieve synced lyrics

### DIFF
--- a/src/api/queryServerInfo.ts
+++ b/src/api/queryServerInfo.ts
@@ -17,6 +17,19 @@ export async function queryServerInfo(url: string) {
       method: 'GET',
     })
     const data = await response.json()
+    
+    const extensionsMap: {[key: string]: number[]} = {}
+    if (data['openSubsonic']) {
+      const eResponse = await fetch(`${url}/rest/getOpenSubsonicExtensions.view?${queries}`, {
+        method: 'GET',
+      })
+
+      const eData = await eResponse.json()
+
+      for (const extension of eData['openSubsonicExtensions']) {
+        extensionsMap[extension['name']] = extension['versions']
+      }
+    }
 
     return {
       protocolVersion: data['subsonic-response'].version,
@@ -24,6 +37,7 @@ export async function queryServerInfo(url: string) {
         data['subsonic-response'].version.replaceAll('.', ''),
       ),
       serverType: data['subsonic-response'].type.toLowerCase() || 'subsonic',
+      extensionsSupported: extensionsMap,
     }
   } catch (_) {
     return {

--- a/src/api/queryServerInfo.ts
+++ b/src/api/queryServerInfo.ts
@@ -19,14 +19,14 @@ export async function queryServerInfo(url: string) {
     const data = await response.json()
     
     const extensionsMap: {[key: string]: number[]} = {}
-    if (data['openSubsonic']) {
-      const eResponse = await fetch(`${url}/rest/getOpenSubsonicExtensions.view?${queries}`, {
+    if (data['subsonic-response']['openSubsonic']) {
+      const response = await fetch(`${url}/rest/getOpenSubsonicExtensions.view?${queries}`, {
         method: 'GET',
       })
 
-      const eData = await eResponse.json()
+      const eData = await response.json()
 
-      for (const extension of eData['openSubsonicExtensions']) {
+      for (const extension of eData['subsonic-response']['openSubsonicExtensions']) {
         extensionsMap[extension['name']] = extension['versions']
       }
     }

--- a/src/app/components/fullscreen/lyrics.tsx
+++ b/src/app/components/fullscreen/lyrics.tsx
@@ -20,12 +20,13 @@ export function LyricsTab() {
   const { currentSong } = usePlayerSonglist()
   const { t } = useTranslation()
 
-  const { artist, title, duration } = currentSong
+  const { id, artist, title, duration } = currentSong
 
   const { data: lyrics, isLoading } = useQuery({
     queryKey: ['get-lyrics', artist, title, duration],
     queryFn: () =>
       subsonic.lyrics.getLyrics({
+        id,
         artist,
         title,
         duration,

--- a/src/service/lyrics.ts
+++ b/src/service/lyrics.ts
@@ -1,10 +1,11 @@
 import { httpClient } from '@/api/httpClient'
 import { usePlayerStore } from '@/store/player.store'
-import { LyricsResponse } from '@/types/responses/song'
+import { ILyric, IStructuredLyric, LyricsResponse, StructuredLyricsResponse } from '@/types/responses/song'
 import { lrclibClient } from '@/utils/appName'
-import { checkServerType } from '@/utils/servers'
+import { checkServerType, getServerExtensions } from '@/utils/servers'
 
 interface GetLyricsData {
+  id: string
   artist: string
   title: string
   album?: string
@@ -21,14 +22,44 @@ interface LRCLibResponse {
 
 async function getLyrics(getLyricsData: GetLyricsData) {
   const { preferSyncedLyrics } = usePlayerStore.getState().settings.lyrics
+  const { songLyricsEnabled } = getServerExtensions()
 
-  // If the user prefers synced lyrics, attempt to fetch them from the LrcLib first.
-  // If lyrics are found, return them immediately.
-  // If not, proceed with the default flow.
+  // First attempt to retrieve lyrics from the server. 
+  // If we know it supports the OpenSubsonic songLyrics extension with timing info, use that.
+  // If the server does not support the extension or the lyrics returned from the server did 
+  // not include timing information, fetch them from the LrcLib
+
+  let osUnsyncedLyricsFound: ILyric | undefined;
+  if (songLyricsEnabled) {
+    const response = await httpClient<StructuredLyricsResponse>('/getLyricsBySongId', {
+      method: 'GET',
+      query: {
+        id: getLyricsData.id,
+      },
+    })
+
+    if (preferSyncedLyrics) {
+      if (response?.data.lyricsList.structuredLyrics && response.data.lyricsList.structuredLyrics.length > 0) {
+        const syncedLyrics = response?.data.lyricsList.structuredLyrics.find((lyrics) => lyrics.synced)
+
+        if (syncedLyrics) {
+          return osStructuredLyricsToILyric(syncedLyrics)
+        }
+        // save the plain lyrics from this call
+        osUnsyncedLyricsFound = osStructuredLyricsToILyric(response.data.lyricsList.structuredLyrics[0])
+      }
+    }
+  }
+  
   if (preferSyncedLyrics) {
     const lyrics = await getLyricsFromLRCLib(getLyricsData)
 
     if (lyrics.value !== '') return lyrics
+  }
+
+  // if the server supported the songLyrics extension and lrc did not have the synced lyrics, return the 
+  if (osUnsyncedLyricsFound) {
+    return osUnsyncedLyricsFound
   }
 
   const response = await httpClient<LyricsResponse>('/getLyrics', {
@@ -121,6 +152,14 @@ async function getLyricsFromLRCLib(getLyricsData: GetLyricsData) {
 
 function formatLyrics(lyrics: string) {
   return lyrics.trim().replaceAll('\r\n', '\n')
+}
+
+function osStructuredLyricsToILyric(lyrics: IStructuredLyric): ILyric {
+  return {
+    artist: lyrics.displayArtist,
+    title: lyrics.displayTitle,
+    value: formatLyrics(lyrics.line.map(l => l.value).join("\n")),
+  } 
 }
 
 export const lyrics = {

--- a/src/store/app.store.ts
+++ b/src/store/app.store.ts
@@ -175,6 +175,7 @@ export const useAppStore = createWithEqualityFn<IAppContext>()(
                     state.data.protocolVersion = serverInfo.protocolVersion
                     state.data.serverType = serverInfo.serverType
                     state.data.isServerConfigured = true
+                    state.data.extensionsSupported = serverInfo.extensionsSupported
                   })
                   return true
                 }
@@ -195,6 +196,7 @@ export const useAppStore = createWithEqualityFn<IAppContext>()(
                 state.data.protocolVersion = '1.16.0'
                 state.data.serverType = 'subsonic'
                 state.data.songCount = null
+                state.data.extensionsSupported = {}
                 state.pages.showInfoPanel = true
                 state.pages.hideRadiosSection = HIDE_RADIOS_SECTION ?? false
                 state.pages.artistsPageViewType = 'table'

--- a/src/types/responses/song.ts
+++ b/src/types/responses/song.ts
@@ -18,6 +18,24 @@ export interface ILyric {
   value?: string
 }
 
+export interface ILyricsList {
+  structuredLyrics: IStructuredLyric[]
+}
+
+export interface IStructuredLyric {
+  displayArtist: string
+  displayTitle: string
+  lang?: string
+  offset?: number
+  synced: boolean
+  line: IStructuredLine[]
+}
+
+export interface IStructuredLine {
+  start?: number
+  value: string
+}
+
 export interface IContributor {
   role: string
   artist: IFeaturedArtist
@@ -80,5 +98,6 @@ export interface TopSongsResponse
   extends SubsonicResponse<{ topSongs: SongList }> {}
 
 export interface LyricsResponse extends SubsonicResponse<{ lyrics: ILyric }> {}
+export interface StructuredLyricsResponse extends SubsonicResponse<{ lyricsList: ILyricsList }> {}
 
 export interface GetSongResponse extends SubsonicResponse<{ song: ISong }> {}

--- a/src/types/serverConfig.ts
+++ b/src/types/serverConfig.ts
@@ -11,6 +11,7 @@ export interface IServerConfig {
   password: string
   protocolVersion?: string
   serverType?: string
+  extensionsSupported?: {[key: string]: number[]}
 }
 
 export type PageViewType = 'grid' | 'table'

--- a/src/utils/servers.ts
+++ b/src/utils/servers.ts
@@ -13,3 +13,13 @@ export function checkServerType() {
     isLms,
   }
 }
+
+export function getServerExtensions() {
+  const { extensionsSupported } = useAppStore.getState().data
+
+  const songLyricsEnabled = extensionsSupported && extensionsSupported['songLyrics'] && extensionsSupported['songLyrics'].length > 0
+
+  return {
+    songLyricsEnabled,
+  }
+}


### PR DESCRIPTION
Navidrome and other Subsonic API compliant servers can implement the OpenSubsonic `songLyrics` extension that allows retrieval of timed lyrics, but it must be done through the `getLyricsBySongId/` endpoint instead of `getLyrics`. (This is what other clients such as Symfonium use to retrieve timed lyrics from the server.)

This PR adds:

* functions to retrieve extensions supported from subsonic servers
* models for OS structured lyric objects
* logic to retrieve synced lyrics from OS servers, falling back to lrclib and plain lyrics if not found
