### PR TITLE
use eye icons for visibility

### DIFF
--- a/src/app/tables/playlists-columns.tsx
+++ b/src/app/tables/playlists-columns.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, ClockIcon, XIcon } from 'lucide-react'
+import { Eye, EyeOff, CheckIcon, ClockIcon, XIcon } from 'lucide-react'
 import { Link } from 'react-router-dom'
 
 import { PlaylistOptions } from '@/app/components/playlist/options'
@@ -131,9 +131,9 @@ export function playlistsColumns(): ColumnDefType<Playlist>[] {
       cell: ({ row }) => (
         <div>
           {row.original.public ? (
-            <CheckIcon className="w-5 h-5 text-green-500" />
+            <Eye className="w-5 h-5 text-white-500" />
           ) : (
-            <XIcon className="w-5 h-5 text-red-500" />
+            <EyeOff className="w-5 h-5 text-gray-500" />
           )}
         </div>
       ),


### PR DESCRIPTION
Currently the icons used for public and private playlists are a red x and green check.
This PR replaces those with eye icons from the same package.

<img width="1233" height="295" alt="aonsoku-eye" src="https://github.com/user-attachments/assets/e3a662ab-a36b-4d9e-8aa9-6733d6a91278" />
