### PR TITLE
show more file quality info

### DIFF
--- a/src/app/components/fullscreen/song-info.tsx
+++ b/src/app/components/fullscreen/song-info.tsx
@@ -5,9 +5,12 @@ import { Badge } from '@/app/components/ui/badge'
 import { usePlayerStore } from '@/store/player.store'
 import { ISong } from '@/types/responses/song'
 import { ALBUM_ARTISTS_MAX_NUMBER } from '@/utils/multipleArtists'
+import { SimpleTooltip } from '@/app/components/ui/simple-tooltip'
 import { FullscreenSongImage } from './song-image'
+import i18n from '@/i18n'
 
 const MemoFullscreenSongImage = memo(FullscreenSongImage)
+const MemoSimpleTooltip = memo(SimpleTooltip)
 
 export function SongInfo() {
   const currentSong = usePlayerStore((state) => state.songlist.currentSong)
@@ -29,7 +32,33 @@ export function SongInfo() {
           <Dot className="text-foreground/70" />
           <ArtistNames song={currentSong} />
         </div>
-        <div className="flex gap-2 mt-2 2xl:mt-3 mb-[1px]">
+        <div className="mt-5 text-base 1xl:text-lg flex gap-2 text-foreground/70 truncate maskImage-marquee-fade-finished">
+          
+          {currentSong.bitRate && (
+          <div className="truncate drop-shadow-lg text-foreground">
+            {i18n.t('table.columns.bitrate')} <Badge variant="neutral" >{currentSong.bitRate}</Badge>
+          </div>
+          )}
+
+          {currentSong.samplingRate && (
+          <div className="ml-2 truncate drop-shadow-lg text-foreground">
+            {i18n.t('table.columns.samplingRate')} <Badge variant="neutral" >{currentSong.samplingRate/1000} kHz</Badge>
+          </div>
+          )}
+
+          {currentSong.size && (
+          <div className="ml-2 truncate drop-shadow-lg text-foreground">
+            {i18n.t('table.columns.size')} <Badge variant="neutral" >{ (currentSong.size/1024/1024).toFixed(2) } MB</Badge>
+          </div>
+          )}
+
+          {currentSong.size && (
+          <div className="ml-2 truncate drop-shadow-lg text-foreground">
+            {i18n.t('table.columns.quality')} <Badge variant="neutral" >{ currentSong.suffix.toUpperCase() } </Badge>
+          </div>
+          )}
+        </div>
+        <div className="flex gap-2 mt-3 2xl:mt-3 mb-[1px]">
           {currentSong.genre && (
             <Badge variant="neutral">{currentSong.genre}</Badge>
           )}

--- a/src/app/tables/songs-columns.tsx
+++ b/src/app/tables/songs-columns.tsx
@@ -251,9 +251,18 @@ export function songsColumns(): ColumnDefType<ISong>[] {
       },
       className: 'hidden 2xl:flex',
       cell: ({ row }) => {
-        const { suffix } = row.original
-
-        return <MemoBadge>{suffix.toUpperCase()}</MemoBadge>
+        //const { suffix } = row.original
+        const { suffix, bitRate, size } = row.original;
+        const tooltipContent = `
+          ${i18n.t('table.columns.quality')}: ${suffix}
+          ${i18n.t('table.columns.bitrate')}: ${bitRate}
+          ${i18n.t('table.columns.size')}: ${size/1024/1024 > 1 ? (size/1024/1024).toFixed(2) + ' MB' : (size/1024).toFixed(2) + ' KB'}
+          `;
+        return <MemoSimpleTooltip text={tooltipContent}>
+          <div>
+          <MemoBadge variant="secondary">{suffix.toUpperCase()}</MemoBadge>
+          </div>
+        </MemoSimpleTooltip>
       },
     },
     {


### PR DESCRIPTION
- Adds a tooltip to the 'quality' badge in the songs list to show bitrate and file size on mouseover.

- On the fullscreen / extended player shows bitrate, sample rate etc for the current song


Relevant Issues: https://github.com/victoralvesf/aonsoku/issues/226 

<img width="658" height="110" alt="aonsoku-tooltip" src="https://github.com/user-attachments/assets/4f85fc0c-9363-4871-afe0-38e7a05c2143" />

<img width="1262" height="819" alt="aonsoku-fullscreen-file-quality" src="https://github.com/user-attachments/assets/3fe18bf0-195b-445a-9649-58d52134aa5b" />
