### PR TITLE
add a prominent button to expand to the big player

### DIFF
--- a/src/app/components/player/expand-button.tsx
+++ b/src/app/components/player/expand-button.tsx
@@ -1,0 +1,29 @@
+import { Expand } from 'lucide-react'
+import FullscreenMode from '@/app/components/fullscreen/page'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/app/components/ui/button'
+import { SimpleTooltip } from '@/app/components/ui/simple-tooltip'
+
+interface PlayerExpandButtonProps {
+  disabled: boolean
+}
+
+export function PlayerExpandButton({}: PlayerExpandButtonProps) {
+  const { t } = useTranslation()
+
+  return (
+    <SimpleTooltip text={t('fullscreen.switchButton')}>
+        <FullscreenMode>
+            <Button
+                variant="ghost"
+                className="rounded-full w-10 h-10 p-3 text-secondary-foreground"
+                data-testid="player-expand-button"
+            >
+                <Expand
+                data-testid="player-expand-icon"
+                />
+            </Button>
+      </FullscreenMode>
+    </SimpleTooltip>
+  )
+}

--- a/src/app/components/player/player.tsx
+++ b/src/app/components/player/player.tsx
@@ -23,6 +23,7 @@ import { ReplayGainParams } from '@/utils/replayGain'
 import { AudioPlayer } from './audio'
 import { PlayerClearQueueButton } from './clear-queue-button'
 import { PlayerControls } from './controls'
+import { PlayerExpandButton } from './expand-button'
 import { PlayerLikeButton } from './like-button'
 import { PlayerLyricsButton } from './lyrics-button'
 import { PodcastInfo } from './podcast-info'
@@ -40,6 +41,7 @@ const MemoPlayerLikeButton = memo(PlayerLikeButton)
 const MemoPlayerQueueButton = memo(PlayerQueueButton)
 const MemoPlayerClearQueueButton = memo(PlayerClearQueueButton)
 const MemoPlayerVolume = memo(PlayerVolume)
+const MemoPlayerExpandButton = memo(PlayerExpandButton)
 const MemoPodcastPlaybackRate = memo(PodcastPlaybackRate)
 const MemoLyricsButton = memo(PlayerLyricsButton)
 const MemoMiniPlayerButton = memo(MiniPlayerButton)
@@ -203,6 +205,7 @@ export function Player() {
           <div className="flex items-center gap-1">
             {isSong && (
               <>
+                <MemoPlayerExpandButton disabled={!song} />
                 <MemoPlayerLikeButton disabled={!song} />
                 <MemoLyricsButton disabled={!song} />
                 <MemoPlayerQueueButton disabled={!song} />


### PR DESCRIPTION
Adds an extra icon beside the like and lyrics icons for expanding the player to the big player.

Relevant issue: https://github.com/victoralvesf/aonsoku/issues/231

<img width="1138" height="101" alt="aonsoku-expand" src="https://github.com/user-attachments/assets/90546256-a039-496d-aade-0c0a50d457fb" />
