### PR TITLE
feat: add sorting options for songs tab

### DIFF
--- a/src/app/components/songs/songs-filters.tsx
+++ b/src/app/components/songs/songs-filters.tsx
@@ -1,0 +1,108 @@
+import { ArrowDown, ArrowUp, ListFilterIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
+import { Button } from '@/app/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/app/components/ui/dropdown-menu'
+import { SimpleTooltip } from '@/app/components/ui/simple-tooltip'
+import { SongsOrderByOptions, SortOptions } from '@/utils/albumsFilter'
+import { SearchParamsHandler } from '@/utils/searchParamsHandler'
+
+interface SortFilterProps {
+  defaultSort?: SortOptions
+}
+
+export function SongsSortFilter({
+  defaultSort = SortOptions.Desc,
+}: SortFilterProps) {
+  const { t } = useTranslation()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { getSearchParam } = new SearchParamsHandler(searchParams)
+  const { Asc, Desc } = SortOptions
+
+  const sortFilter = getSearchParam<SortOptions>('sort', defaultSort)
+  const isDesc = sortFilter === Desc
+
+  function sortFilterTooltip() {
+    if (isDesc) {
+      return t('table.sort.asc')
+    } else {
+      return t('table.sort.desc')
+    }
+  }
+
+  function handleChangeSort() {
+    setSearchParams((state) => {
+      state.set('sort', isDesc ? Asc : Desc)
+      return state
+    })
+  }
+
+  return (
+    <SimpleTooltip text={sortFilterTooltip()}>
+      <Button
+        variant="outline"
+        className="w-9 h-9 p-0"
+        size="sm"
+        onClick={handleChangeSort}
+      >
+        {isDesc ? (
+          <ArrowDown className="w-4 h-4" />
+        ) : (
+          <ArrowUp className="w-4 h-4" />
+        )}
+      </Button>
+    </SimpleTooltip>
+  )
+}
+
+export function SongsOrderByFilter() {
+  const { t } = useTranslation()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { getSearchParam } = new SearchParamsHandler(searchParams)
+  const { LastAdded, Artist, Title, Album } = SongsOrderByOptions
+
+  const orderByFilter = getSearchParam<SongsOrderByOptions>(
+    'orderBy',
+    LastAdded,
+  )
+
+  function handleChangeFilter(value: SongsOrderByOptions) {
+    setSearchParams((state) => {
+      state.set('orderBy', value)
+      return state
+    })
+  }
+
+  const filters = [
+    { label: 'songs.sort.lastAdded', option: LastAdded },
+    { label: 'songs.sort.artist', option: Artist },
+    { label: 'songs.sort.title', option: Title },
+    { label: 'songs.sort.album', option: Album },
+  ]
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" className="w-9 h-9 p-0" size="sm">
+          <ListFilterIcon className="w-4 h-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-[200px]">
+        {filters.map(({ label, option }) => (
+          <DropdownMenuCheckboxItem
+            key={option}
+            checked={orderByFilter === option}
+            onCheckedChange={() => handleChangeFilter(option)}
+          >
+            {t(label)}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/app/pages/songs/songlist.tsx
+++ b/src/app/pages/songs/songlist.tsx
@@ -6,13 +6,14 @@ import { InfinitySongListFallback } from '@/app/components/fallbacks/song-fallba
 import { HeaderTitle } from '@/app/components/header-title'
 import { ClearFilterButton } from '@/app/components/search/clear-filter-button'
 import { ExpandableSearchInput } from '@/app/components/search/expandable-input'
+import { SongsOrderByFilter, SongsSortFilter } from '@/app/components/songs/songs-filters'
 import { DataTableList } from '@/app/components/ui/data-table-list'
 import { useTotalSongs } from '@/app/hooks/use-total-songs'
 import { songsColumns } from '@/app/tables/songs-columns'
 import { getArtistAllSongs, songsSearch } from '@/queries/songs'
 import { usePlayerActions } from '@/store/player.store'
 import { ColumnFilter } from '@/types/columnFilter'
-import { AlbumsFilters, AlbumsSearchParams } from '@/utils/albumsFilter'
+import { AlbumsFilters, AlbumsSearchParams, SongsOrderByOptions, SortOptions } from '@/utils/albumsFilter'
 import { queryKeys } from '@/utils/queryKeys'
 import { SearchParamsHandler } from '@/utils/searchParamsHandler'
 
@@ -29,6 +30,8 @@ export default function SongList() {
   const query = getSearchParam<string>(AlbumsSearchParams.Query, '')
   const artistId = getSearchParam<string>(AlbumsSearchParams.ArtistId, '')
   const artistName = getSearchParam<string>(AlbumsSearchParams.ArtistName, '')
+  const orderBy = getSearchParam<SongsOrderByOptions>('orderBy', SongsOrderByOptions.LastAdded)
+  const sort = getSearchParam<SortOptions>('sort', SortOptions.Desc)
 
   const searchFilterIsSet = filter === AlbumsFilters.Search && query !== ''
   const filterByArtist = artistId !== '' && artistName !== ''
@@ -36,19 +39,21 @@ export default function SongList() {
 
   async function fetchSongs({ pageParam = 0 }) {
     if (filterByArtist) {
-      return getArtistAllSongs(artistId)
+      return getArtistAllSongs(artistId, { orderBy, sort })
     }
 
     return songsSearch({
       query: searchFilterIsSet ? query : '',
       songCount: DEFAULT_OFFSET,
       songOffset: pageParam,
+      orderBy,
+      sort,
     })
   }
 
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
     useInfiniteQuery({
-      queryKey: [queryKeys.song.all, filter, query, artistId],
+      queryKey: [queryKeys.song.all, filter, query, artistId, orderBy, sort],
       initialPageParam: 0,
       queryFn: fetchSongs,
       getNextPageParam: (lastPage) => lastPage.nextOffset,
@@ -102,6 +107,8 @@ export default function SongList() {
           <ExpandableSearchInput
             placeholder={t('songs.list.search.placeholder')}
           />
+          <SongsSortFilter />
+          <SongsOrderByFilter />
         </div>
       </ShadowHeader>
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -132,6 +132,12 @@
       "filter": {
         "clear": "Clear filter"
       }
+    },
+    "sort": {
+      "lastAdded": "Last Added",
+      "artist": "Artist A-Z",
+      "title": "Song A-Z",
+      "album": "Album A-Z"
     }
   },
   "album": {

--- a/src/queries/songs.ts
+++ b/src/queries/songs.ts
@@ -1,34 +1,139 @@
 import { SearchQueryOptions } from '@/service/search'
 import { subsonic } from '@/service/subsonic'
+import { SongsOrderByOptions, SortOptions } from '@/utils/albumsFilter'
+import { ISong } from '@/types/responses/song'
 
 const emptyResponse = { songs: [], nextOffset: null }
 
 type SongSearchParams = Required<
   Pick<SearchQueryOptions, 'query' | 'songCount' | 'songOffset'>
->
+> & {
+  orderBy?: SongsOrderByOptions
+  sort?: SortOptions
+}
 
-export async function songsSearch(params: SongSearchParams) {
+interface ArtistSongsParams {
+  orderBy?: SongsOrderByOptions
+  sort?: SortOptions
+}
+
+function sortSongs(songs: ISong[], orderBy: SongsOrderByOptions, sort: SortOptions): ISong[] {
+  const isAsc = sort === SortOptions.Asc
+  
+  return songs.sort((a, b) => {
+    let comparison = 0
+    
+    switch (orderBy) {
+      case SongsOrderByOptions.LastAdded:
+        comparison = new Date(a.created).getTime() - new Date(b.created).getTime()
+        break
+      case SongsOrderByOptions.Artist:
+        comparison = (a.artist || '').localeCompare(b.artist || '')
+        break
+      case SongsOrderByOptions.Title:
+        comparison = (a.title || '').localeCompare(b.title || '')
+        break
+      case SongsOrderByOptions.Album:
+        comparison = (a.album || '').localeCompare(b.album || '')
+        break
+      default:
+        comparison = new Date(a.created).getTime() - new Date(b.created).getTime()
+    }
+    
+    return isAsc ? comparison : -comparison
+  })
+}
+
+// Cache for all songs to avoid refetching
+let allSongsCache: { songs: any[], timestamp: number } | null = null
+const CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
+
+async function getAllSongs(orderBy = SongsOrderByOptions.LastAdded, sort = SortOptions.Desc) {
+  // Check cache first
+  const now = Date.now()
+  if (allSongsCache && allSongsCache.timestamp && (now - allSongsCache.timestamp) < CACHE_DURATION) {
+    // Re-sort cached songs if sorting changed
+    return sortSongs(allSongsCache.songs, orderBy, sort)
+  }
+
+  // Fetch all songs by using a very large count
+  // For search queries, we need to fetch with empty query to get all songs
   const response = await subsonic.search.get({
+    query: '',
     artistCount: 0,
     albumCount: 0,
-    ...params,
+    songCount: 999999,
+    songOffset: 0,
   })
 
-  if (!response) return emptyResponse
-  if (!response.song) return emptyResponse
+  if (!response || !response.song) return []
+
+  // Update cache with unsorted songs
+  allSongsCache = {
+    songs: response.song,
+    timestamp: now
+  }
+
+  // Return sorted songs
+  return sortSongs(response.song, orderBy, sort)
+}
+
+export async function songsSearch(params: SongSearchParams) {
+  const orderBy = params.orderBy || SongsOrderByOptions.LastAdded
+  const sort = params.sort || SortOptions.Desc
+  
+  // If there's a search query, use the original search behavior
+  if (params.query && params.query.trim() !== '') {
+    const response = await subsonic.search.get({
+      artistCount: 0,
+      albumCount: 0,
+      query: params.query,
+      songCount: params.songCount,
+      songOffset: params.songOffset,
+    })
+
+    if (!response) return emptyResponse
+    if (!response.song) return emptyResponse
+
+    // For search results, sort by the selected criteria
+    const sortedSongs = sortSongs(response.song, orderBy, sort)
+
+    let nextOffset = null
+    if (sortedSongs.length >= params.songCount) {
+      nextOffset = params.songOffset + params.songCount
+    }
+
+    return {
+      songs: sortedSongs,
+      nextOffset,
+    }
+  }
+
+  // For browsing all songs (no search query), fetch all and paginate
+  const allSongs = await getAllSongs(orderBy, sort)
+  
+  if (allSongs.length === 0) return emptyResponse
+
+  // Apply pagination to the sorted results
+  const startIndex = params.songOffset
+  const endIndex = startIndex + params.songCount
+  const paginatedSongs = allSongs.slice(startIndex, endIndex)
 
   let nextOffset = null
-  if (response.song.length >= params.songCount) {
-    nextOffset = params.songOffset + params.songCount
+  if (endIndex < allSongs.length) {
+    nextOffset = endIndex
   }
 
   return {
-    songs: response.song,
+    songs: paginatedSongs,
     nextOffset,
   }
 }
 
-export async function getArtistAllSongs(artistId: string) {
+export async function getArtistAllSongs(artistId: string, params: ArtistSongsParams = {}) {
+  const orderBy = params.orderBy || SongsOrderByOptions.LastAdded
+  const sort = params.sort || SortOptions.Desc
+  
   const artist = await subsonic.artists.getOne(artistId)
 
   if (!artist || !artist.album) return emptyResponse
@@ -43,8 +148,11 @@ export async function getArtistAllSongs(artistId: string) {
     return result.song
   })
 
+  // Sort by the selected criteria
+  const sortedSongs = sortSongs(songs, orderBy, sort)
+
   return {
-    songs,
+    songs: sortedSongs,
     nextOffset: null,
   }
 }

--- a/src/utils/albumsFilter.ts
+++ b/src/utils/albumsFilter.ts
@@ -90,3 +90,10 @@ export enum PodcastsOrderByOptions {
   Title = 'title',
   EpisodeCount = 'episode_count',
 }
+
+export enum SongsOrderByOptions {
+  LastAdded = 'created',
+  Artist = 'artist',
+  Title = 'title',
+  Album = 'album',
+}


### PR DESCRIPTION

## Add sorting options to songs tab

Provides song library sorting with proper global ordering across all pages.

**Changes:**
- Added dropdown to sort songs by Last Added, Artist A-Z, Song A-Z, or Album A-Z
- Added ascending/descending toggle button with arrow icons
- Default sorting is Last Added (descending) - maintains current behavior
- Sorting preferences persist in URL parameters

**Implementation:**
- Created `SongsOrderByFilter` and `SongsSortFilter` components following existing app patterns
- Updated song queries to handle sorting parameters with optimized caching
- Added translation keys for sort options
- Modified songs page header to include sorting UI

**Technical notes:**
- Uses client-side sorting due to Subsonic API limitation (no server-side song sorting parameters)
- **Fetches and caches all songs upfront, then applies sorting and pagination.** This eliminates the lazy loading of 100 songs at a time.
- Maintains existing search functionality while adding sorting capabilities
