### PR TITLE
Fix: Allowed clearing the playlist comment through the UI

### DIFF
--- a/src/service/playlists.ts
+++ b/src/service/playlists.ts
@@ -68,9 +68,9 @@ async function update({
   const query = new URLSearchParams({
     playlistId,
   })
-  if (name) query.append('name', name)
-  if (comment) query.append('comment', comment)
-  if (isPublic) query.append('public', isPublic)
+  if (name !== undefined) query.append('name', name)
+  if (comment !== undefined) query.append('comment', comment)
+  if (isPublic !== undefined) query.append('public', isPublic)
 
   if (songIdToAdd) {
     if (typeof songIdToAdd === 'string') {


### PR DESCRIPTION
Currently, when editing a playlist, clearing the Comment field does not persist that change. This PR makes it so that clearing a playlist's comment is correctly applied.

Reproduction steps: Open a playlist which has a comment, click the kebab menu icon, then Edit Playlist. Empty the playlist comment text field, then press Update. Observe that the original playlist comment remains.

