### PR TITLE
Aonsoku Flatpak App - Missing upstream files

### DIFF
--- a/flatpak/io.github.victoralvesf.aonsoku.desktop
+++ b/flatpak/io.github.victoralvesf.aonsoku.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Comment=A modern desktop client for Navidrome/Subsonic servers.
+Name=Aonsoku
+Exec=aonsoku.sh
+Icon=io.github.victoralvesf.aonsoku
+Categories=Audio;

--- a/flatpak/io.github.victoralvesf.aonsoku.metainfo.xml
+++ b/flatpak/io.github.victoralvesf.aonsoku.metainfo.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.victoralvesf.aonsoku</id>
+
+  <name>Aonsoku</name>
+  <summary>A modern desktop client for Navidrome/Subsonic servers.</summary>
+
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+
+  <description>
+    <p>
+      <h3>Features</h3>
+      <ul>
+        <li>Subsonic Integration: Aonsoku integrates with your Navidrome or Subsonic server, providing you with easy access to your music collection.</li>
+        <li>Intuitive UI: Modern, clean and user-friendly interface designed to enhance your music listening experience.</li>
+        <li>Podcast Support: With Aonsoku Podcasts you can easily access, manage, and listen to your favorites podcasts directly within the app. Enjoy advanced search options, customizable filters and seamless listening synchronization to enhance your podcast experience.</li>
+        <li>Synchronized lyrics: Aonsoku will automatically find a synced lyric from LRCLIB if none is provided by the server.</li>
+        <li>Unsynchronized lyrics: If your songs have embedded unsynchronized lyrics, Aonsoku is able to show them.</li>
+        <li>Radio: If your server supports it, listen to radio shows directly within Aonsoku.</li>
+        <li>Scrobble: Sync played songs with your server.</li>
+      </ul>
+    </p>
+  </description>
+
+  <launchable type="desktop-id">io.github.victoralvesf.aonsoku.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/victoralvesf/aonsoku/e5cb4546f2f874fd24c25045882c908b8032e728/media/home.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/victoralvesf/aonsoku/e5cb4546f2f874fd24c25045882c908b8032e728/media/playlist.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/victoralvesf/aonsoku/e5cb4546f2f874fd24c25045882c908b8032e728/media/artist.png</image>
+    </screenshot>
+  </screenshots>
+</component>


### PR DESCRIPTION
Aonsoku Flatpak app in Flathub.

These two files are required to be available upstream (in this repo), by the Flathub community.
Once they are available here, I'll update the yaml file in the Flathub PR.

[Flathub PR](https://github.com/flathub/flathub/pull/7444) for reference.