### PR TITLE
Suggestion to improve gnome tray icon behavior

### DIFF
--- a/electron/main/core/events.ts
+++ b/electron/main/core/events.ts
@@ -61,14 +61,7 @@ export function setupEvents(window: BrowserWindow | null) {
   })
 
   window.on('close', (event) => {
-    const currentDesktop = (process.env.XDG_CURRENT_DESKTOP || '').toLowerCase()
-    const isGnomeOrUnity = currentDesktop.includes('gnome') || currentDesktop.includes('unity')
-    if (
-      is.dev ||
-      !getAppSetting('minimizeToTray') ||
-      !tray ||
-      (platform.isLinux && isGnomeOrUnity)
-    ) {
+    if (is.dev || !getAppSetting('minimizeToTray')) {
       if (tray && !tray.isDestroyed()) tray.destroy()
       return
     }

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,12 +1,10 @@
 import { electronApp, optimizer, platform } from '@electron-toolkit/utils'
 import { app, globalShortcut } from 'electron'
 
-if (platform.isLinux) {
-
-  if (process.env.XDG_CURRENT_DESKTOP.toLowerCase().includes('gnome')) {
+if (platform.isLinux && process.env.XDG_CURRENT_DESKTOP.toLowerCase().includes('gnome')) {
     process.env.XDG_CURRENT_DESKTOP = 'Unity'
-  }
 }
+
 import { createAppMenu } from './core/menu'
 import { createWindow, mainWindow } from './window'
 


### PR DESCRIPTION
Gnome does not have a tray icon dock by default, so I suggest that we shouldn't close/minimize to tray (on Gnome only).
Instead,
- the window close button should actually close the app;
- the window minimize button should minimize to the default dock.

If a Tray Icon Gnome extension is installed (such as AppIndicator), these changes still make the tray display properly.

I must warn, though, that I've tested this change on Gnome and KDE Plasma, using a flatpak package build.
Any help with other OSs/packaging is welcome.