### PR TITLE
add visual feedback for playback start; add general playback provenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ env-config.js
 .env
 
 out
+
+.pnpm-store/*

--- a/src/app/components/actions.tsx
+++ b/src/app/components/actions.tsx
@@ -34,6 +34,7 @@ interface ActionsMainButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
   tooltip?: string
   buttonStyle?: 'primary' | 'secondary'
+  isActive?: boolean
 }
 
 function Button({
@@ -41,6 +42,7 @@ function Button({
   tooltip,
   buttonStyle = 'secondary',
   className,
+  isActive = false,
   ...props
 }: ActionsMainButtonProps) {
   const button = (
@@ -52,6 +54,7 @@ function Button({
           ? 'hover:scale-105 mr-2'
           : 'hover:bg-foreground/20',
         className,
+        isActive && 'pointer-events-none text-primary',
       )}
       variant={buttonStyle === 'primary' ? 'default' : 'ghost'}
       {...props}

--- a/src/app/components/album/buttons.tsx
+++ b/src/app/components/album/buttons.tsx
@@ -3,7 +3,11 @@ import { useTranslation } from 'react-i18next'
 import { Actions } from '@/app/components/actions'
 import { subsonic } from '@/service/subsonic'
 import { useAppPages } from '@/store/app.store'
-import { usePlayerActions } from '@/store/player.store'
+import {
+  usePlayerActions,
+  usePlayerContext,
+  usePlayerStore,
+} from '@/store/player.store'
 import { SingleAlbum } from '@/types/responses/album'
 import { queryKeys } from '@/utils/queryKeys'
 import { AlbumOptions } from './options'
@@ -15,9 +19,13 @@ interface AlbumButtonsProps {
 
 export function AlbumButtons({ album, showInfoButton }: AlbumButtonsProps) {
   const { t } = useTranslation()
-  const { setSongList } = usePlayerActions()
+  const { setSongList, togglePlayPause } = usePlayerActions()
   const { showInfoPanel, toggleShowInfoPanel } = useAppPages()
-
+  const { source } = usePlayerContext()
+  const isPlaying = usePlayerStore((state) => state.playerState.isPlaying)
+  const isShuffleActive = usePlayerStore(
+    (state) => state.playerState.isShuffleActive,
+  )
   const isAlbumStarred = album.starred !== undefined
 
   const queryClient = useQueryClient()
@@ -54,20 +62,48 @@ export function AlbumButtons({ album, showInfoButton }: AlbumButtonsProps) {
     },
   }
 
+  const isCurrentAlbumActive =
+    source?.type === 'album' && source.id === album.id
+  const isAlbumPlaying = isPlaying && isCurrentAlbumActive
+
   return (
     <Actions.Container>
-      <Actions.Button
-        tooltip={buttonsTooltips.play}
-        buttonStyle="primary"
-        onClick={() => setSongList(album.song, 0)}
-      >
-        <Actions.PlayIcon />
-      </Actions.Button>
+      {!isAlbumPlaying && (
+        <Actions.Button
+          tooltip={buttonsTooltips.play}
+          buttonStyle="primary"
+          onClick={() =>
+            setSongList(album.song, 0, false, {
+              id: album.id,
+              name: album.name,
+              type: 'album',
+            })
+          }
+        >
+          <Actions.PlayIcon />
+        </Actions.Button>
+      )}
+      {isAlbumPlaying && (
+        <Actions.Button
+          tooltip={buttonsTooltips.play}
+          buttonStyle="primary"
+          onClick={togglePlayPause}
+        >
+          <Actions.PauseIcon />
+        </Actions.Button>
+      )}
 
       {album.song.length > 1 && (
         <Actions.Button
           tooltip={buttonsTooltips.shuffle}
-          onClick={() => setSongList(album.song, 0, true)}
+          onClick={() =>
+            setSongList(album.song, 0, true, {
+              id: album.id,
+              name: album.name,
+              type: 'album',
+            })
+          }
+          isActive={isAlbumPlaying && isShuffleActive}
         >
           <Actions.ShuffleIcon />
         </Actions.Button>

--- a/src/app/components/albums/album-grid-card.tsx
+++ b/src/app/components/albums/album-grid-card.tsx
@@ -1,9 +1,14 @@
+import clsx from 'clsx'
 import { memo } from 'react'
 import { ImageLoader } from '@/app/components/image-loader'
 import { PreviewCard } from '@/app/components/preview-card/card'
 import { ROUTES } from '@/routes/routesList'
 import { subsonic } from '@/service/subsonic'
-import { usePlayerActions } from '@/store/player.store'
+import {
+  usePlayerActions,
+  usePlayerContext,
+  usePlayerStore,
+} from '@/store/player.store'
 import { Albums } from '@/types/responses/album'
 
 type AlbumCardProps = {
@@ -11,23 +16,43 @@ type AlbumCardProps = {
 }
 
 function AlbumCard({ album }: AlbumCardProps) {
-  const { setSongList } = usePlayerActions()
+  const { setSongList, togglePlayPause } = usePlayerActions()
+  const { source } = usePlayerContext()
+  const isPlaying = usePlayerStore((state) => state.playerState.isPlaying)
 
   async function handlePlayAlbum() {
     const response = await subsonic.albums.getOne(album.id)
 
     if (response) {
-      setSongList(response.song, 0)
+      setSongList(response.song, 0, false, {
+        id: response.id,
+        name: response.name,
+        type: 'album',
+      })
     }
   }
 
+  const isCurrentAlbumActive =
+    source?.type === 'album' && source.id === album.id
+  const isAlbumPlayingNow = isPlaying && isCurrentAlbumActive
+
   return (
-    <PreviewCard.Root>
+    <PreviewCard.Root className={clsx(isAlbumPlayingNow && 'border-primary')}>
       <PreviewCard.ImageWrapper link={ROUTES.ALBUM.PAGE(album.id)}>
         <ImageLoader id={album.coverArt} type="album" size={300}>
           {(src) => <PreviewCard.Image src={src} alt={album.name} />}
         </ImageLoader>
-        <PreviewCard.PlayButton onClick={handlePlayAlbum} />
+        {isAlbumPlayingNow ? (
+          <PreviewCard.PauseButton
+            isActive={isCurrentAlbumActive}
+            onClick={togglePlayPause}
+          />
+        ) : (
+          <PreviewCard.PlayButton
+            isActive={isCurrentAlbumActive}
+            onClick={handlePlayAlbum}
+          />
+        )}
       </PreviewCard.ImageWrapper>
       <PreviewCard.InfoWrapper>
         <PreviewCard.Title link={ROUTES.ALBUM.PAGE(album.id)}>

--- a/src/app/components/artist/artist-grid-card.tsx
+++ b/src/app/components/artist/artist-grid-card.tsx
@@ -4,7 +4,11 @@ import { ImageLoader } from '@/app/components/image-loader'
 import { PreviewCard } from '@/app/components/preview-card/card'
 import { useSongList } from '@/app/hooks/use-song-list'
 import { ROUTES } from '@/routes/routesList'
-import { usePlayerActions } from '@/store/player.store'
+import {
+  usePlayerActions,
+  usePlayerContext,
+  usePlayerStore,
+} from '@/store/player.store'
 import { ISimilarArtist } from '@/types/responses/artist'
 
 type ArtistCardProps = {
@@ -14,15 +18,25 @@ type ArtistCardProps = {
 function ArtistCard({ artist }: ArtistCardProps) {
   const { t } = useTranslation()
   const { getArtistAllSongs } = useSongList()
-  const { setSongList } = usePlayerActions()
+  const { setSongList, togglePlayPause } = usePlayerActions()
+  const { source } = usePlayerContext()
+  const isPlaying = usePlayerStore((state) => state.playerState.isPlaying)
 
   const handlePlayArtistRadio = useCallback(async () => {
     const songList = await getArtistAllSongs(artist.name)
 
     if (songList) {
-      setSongList(songList, 0)
+      setSongList(songList, 0, false, {
+        id: artist.id,
+        name: artist.name,
+        type: 'artist',
+      })
     }
-  }, [artist.name, getArtistAllSongs, setSongList])
+  }, [artist, getArtistAllSongs, setSongList])
+
+  const isCurrentArtistActive =
+    source?.type === 'artist' && source.id === artist.id
+  const isArtistPlaying = isPlaying && isCurrentArtistActive
 
   return (
     <PreviewCard.Root className="flex flex-col w-full h-full">
@@ -30,7 +44,17 @@ function ArtistCard({ artist }: ArtistCardProps) {
         <ImageLoader id={artist.coverArt} type="artist" size={300}>
           {(src) => <PreviewCard.Image src={src} alt={artist.name} />}
         </ImageLoader>
-        <PreviewCard.PlayButton onClick={handlePlayArtistRadio} />
+        {isArtistPlaying ? (
+          <PreviewCard.PauseButton
+            isActive={isCurrentArtistActive}
+            onClick={togglePlayPause}
+          />
+        ) : (
+          <PreviewCard.PlayButton
+            onClick={handlePlayArtistRadio}
+            isActive={isCurrentArtistActive}
+          />
+        )}
       </PreviewCard.ImageWrapper>
       <PreviewCard.InfoWrapper>
         <PreviewCard.Title link={ROUTES.ARTIST.PAGE(artist.id)}>

--- a/src/app/components/artist/buttons.tsx
+++ b/src/app/components/artist/buttons.tsx
@@ -4,7 +4,11 @@ import { Actions } from '@/app/components/actions'
 import { useSongList } from '@/app/hooks/use-song-list'
 import { subsonic } from '@/service/subsonic'
 import { useAppPages } from '@/store/app.store'
-import { usePlayerActions } from '@/store/player.store'
+import {
+  usePlayerActions,
+  usePlayerContext,
+  usePlayerStore,
+} from '@/store/player.store'
 import { IArtist } from '@/types/responses/artist'
 import { queryKeys } from '@/utils/queryKeys'
 import { ArtistOptions } from './options'
@@ -21,10 +25,14 @@ export function ArtistButtons({
   isArtistEmpty,
 }: ArtistButtonsProps) {
   const { t } = useTranslation()
-  const { setSongList } = usePlayerActions()
+  const { setSongList, togglePlayPause } = usePlayerActions()
   const { showInfoPanel, toggleShowInfoPanel } = useAppPages()
   const { getArtistAllSongs } = useSongList()
-
+  const { source } = usePlayerContext()
+  const isPlaying = usePlayerStore((state) => state.playerState.isPlaying)
+  const isShuffleActive = usePlayerStore(
+    (state) => state.playerState.isShuffleActive,
+  )
   const isArtistStarred = artist.starred !== undefined
 
   const queryClient = useQueryClient()
@@ -50,7 +58,11 @@ export function ArtistButtons({
     const songList = await getArtistAllSongs(artist?.name || '')
 
     if (songList) {
-      setSongList(songList, 0, shuffle)
+      setSongList(songList, 0, shuffle, {
+        id: artist.id,
+        name: artist.name,
+        type: 'artist',
+      })
     }
   }
 
@@ -72,19 +84,35 @@ export function ArtistButtons({
     return <div className="h-8 w-full" />
   }
 
+  const isCurrentArtistActive =
+    source?.type === 'artist' && source.id === artist.id
+  const isArtistPlaying = isPlaying && isCurrentArtistActive
+
   return (
     <Actions.Container>
-      <Actions.Button
-        tooltip={buttonsTooltips.play}
-        buttonStyle="primary"
-        onClick={() => handlePlayArtistRadio()}
-      >
-        <Actions.PlayIcon />
-      </Actions.Button>
+      {!isArtistPlaying && (
+        <Actions.Button
+          tooltip={buttonsTooltips.play}
+          buttonStyle="primary"
+          onClick={() => handlePlayArtistRadio()}
+        >
+          <Actions.PlayIcon />
+        </Actions.Button>
+      )}
+      {isArtistPlaying && (
+        <Actions.Button
+          tooltip={buttonsTooltips.play}
+          buttonStyle="primary"
+          onClick={togglePlayPause}
+        >
+          <Actions.PauseIcon />
+        </Actions.Button>
+      )}
 
       <Actions.Button
         tooltip={buttonsTooltips.shuffle}
         onClick={() => handlePlayArtistRadio(true)}
+        isActive={isArtistPlaying && isShuffleActive}
       >
         <Actions.ShuffleIcon />
       </Actions.Button>

--- a/src/app/components/artist/related-artists.tsx
+++ b/src/app/components/artist/related-artists.tsx
@@ -10,7 +10,11 @@ import {
 import { CarouselButton } from '@/app/components/ui/carousel-button'
 import { useSongList } from '@/app/hooks/use-song-list'
 import { ROUTES } from '@/routes/routesList'
-import { usePlayerActions } from '@/store/player.store'
+import {
+  usePlayerActions,
+  usePlayerContext,
+  usePlayerStore,
+} from '@/store/player.store'
 import { ISimilarArtist } from '@/types/responses/artist'
 
 interface RelatedArtistsListProps {
@@ -27,7 +31,9 @@ export default function RelatedArtistsList({
   const [api, setApi] = useState<CarouselApi>()
   const [canScrollPrev, setCanScrollPrev] = useState<boolean>()
   const [canScrollNext, setCanScrollNext] = useState<boolean>()
-  const { setSongList } = usePlayerActions()
+  const { setSongList, togglePlayPause } = usePlayerActions()
+  const { source } = usePlayerContext()
+  const isPlaying = usePlayerStore((state) => state.playerState.isPlaying)
 
   if (similarArtists.length > 16) {
     similarArtists = similarArtists.slice(0, 16)
@@ -35,7 +41,13 @@ export default function RelatedArtistsList({
 
   async function handlePlayArtistRadio(artist: ISimilarArtist) {
     const songList = await getArtistAllSongs(artist.name)
-    if (songList) setSongList(songList, 0)
+    if (songList) {
+      setSongList(songList, 0, false, {
+        id: artist.id,
+        name: artist.name,
+        type: 'artist',
+      })
+    }
   }
 
   useEffect(() => {
@@ -81,32 +93,49 @@ export default function RelatedArtistsList({
           setApi={setApi}
         >
           <CarouselContent>
-            {similarArtists.map((artist) => (
-              <CarouselItem key={artist.id} className="basis-1/6 2xl:basis-1/8">
-                <PreviewCard.Root>
-                  <PreviewCard.ImageWrapper
-                    link={ROUTES.ARTIST.PAGE(artist.id)}
-                  >
-                    <ImageLoader id={artist.coverArt} type="artist">
-                      {(src) => (
-                        <PreviewCard.Image src={src} alt={artist.name} />
-                      )}
-                    </ImageLoader>
-                    <PreviewCard.PlayButton
-                      onClick={() => handlePlayArtistRadio(artist)}
-                    />
-                  </PreviewCard.ImageWrapper>
-                  <PreviewCard.InfoWrapper>
-                    <PreviewCard.Subtitle
+            {similarArtists.map((artist) => {
+              const isRelatedArtistActive =
+                source?.type === 'artist' && source.id === artist.id
+              const isArtistPlaying = isRelatedArtistActive && isPlaying
+              return (
+                <CarouselItem
+                  key={artist.id}
+                  className="basis-1/6 2xl:basis-1/8"
+                >
+                  <PreviewCard.Root>
+                    <PreviewCard.ImageWrapper
                       link={ROUTES.ARTIST.PAGE(artist.id)}
-                      className="mt-2"
                     >
-                      {artist.name}
-                    </PreviewCard.Subtitle>
-                  </PreviewCard.InfoWrapper>
-                </PreviewCard.Root>
-              </CarouselItem>
-            ))}
+                      <ImageLoader id={artist.coverArt} type="artist">
+                        {(src) => (
+                          <PreviewCard.Image src={src} alt={artist.name} />
+                        )}
+                      </ImageLoader>
+                      {!isArtistPlaying && (
+                        <PreviewCard.PlayButton
+                          onClick={() => handlePlayArtistRadio(artist)}
+                          isActive={isRelatedArtistActive}
+                        />
+                      )}
+                      {isArtistPlaying && (
+                        <PreviewCard.PauseButton
+                          isActive={isRelatedArtistActive}
+                          onClick={togglePlayPause}
+                        />
+                      )}
+                    </PreviewCard.ImageWrapper>
+                    <PreviewCard.InfoWrapper>
+                      <PreviewCard.Subtitle
+                        link={ROUTES.ARTIST.PAGE(artist.id)}
+                        className="mt-2"
+                      >
+                        {artist.name}
+                      </PreviewCard.Subtitle>
+                    </PreviewCard.InfoWrapper>
+                  </PreviewCard.Root>
+                </CarouselItem>
+              )
+            })}
           </CarouselContent>
         </Carousel>
       </div>

--- a/src/app/components/command/album-result.tsx
+++ b/src/app/components/command/album-result.tsx
@@ -28,9 +28,14 @@ export function CommandAlbumResult({
   const { getAlbumSongs } = useSongList()
   const { setSongList } = usePlayerActions()
 
-  async function handlePlayAlbum(albumId: string) {
-    const albumSongs = await getAlbumSongs(albumId)
-    if (albumSongs) setSongList(albumSongs, 0)
+  async function handlePlayAlbum(album: Albums) {
+    const albumSongs = await getAlbumSongs(album.id)
+    if (albumSongs)
+      setSongList(albumSongs, 0, false, {
+        id: album.id,
+        name: album.name,
+        type: 'album',
+      })
   }
 
   return (
@@ -61,7 +66,7 @@ export function CommandAlbumResult({
                 coverArtType="album"
                 title={album.name}
                 artist={album.artist}
-                onClick={() => handlePlayAlbum(album.id)}
+                onClick={() => handlePlayAlbum(album)}
               />
             </CommandItem>
           ))}

--- a/src/app/components/home/preview-list.tsx
+++ b/src/app/components/home/preview-list.tsx
@@ -12,7 +12,11 @@ import {
 import { CarouselButton } from '@/app/components/ui/carousel-button'
 import { ROUTES } from '@/routes/routesList'
 import { subsonic } from '@/service/subsonic'
-import { usePlayerActions } from '@/store/player.store'
+import {
+  usePlayerActions,
+  usePlayerContext,
+  usePlayerStore,
+} from '@/store/player.store'
 import { Albums } from '@/types/responses/album'
 
 interface PreviewListProps {
@@ -33,8 +37,10 @@ export default function PreviewList({
   const [api, setApi] = useState<CarouselApi>()
   const [canScrollPrev, setCanScrollPrev] = useState<boolean>()
   const [canScrollNext, setCanScrollNext] = useState<boolean>()
-  const { setSongList } = usePlayerActions()
+  const { setSongList, togglePlayPause } = usePlayerActions()
   const { t } = useTranslation()
+  const { source } = usePlayerContext()
+  const isPlaying = usePlayerStore((state) => state.playerState.isPlaying)
 
   moreTitle = moreTitle || t('generic.seeMore')
 
@@ -46,7 +52,11 @@ export default function PreviewList({
     const response = await subsonic.albums.getOne(album.id)
 
     if (response) {
-      setSongList(response.song, 0)
+      setSongList(response.song, 0, false, {
+        id: album.id,
+        name: album.name,
+        type: 'album',
+      })
     }
   }
 
@@ -108,37 +118,53 @@ export default function PreviewList({
           data-testid="preview-list-carousel"
         >
           <CarouselContent>
-            {list.map((album, index) => (
-              <CarouselItem
-                key={album.id}
-                className="basis-1/6 2xl:basis-1/8"
-                data-testid={`preview-list-carousel-item-${index}`}
-              >
-                <PreviewCard.Root>
-                  <PreviewCard.ImageWrapper link={ROUTES.ALBUM.PAGE(album.id)}>
-                    <ImageLoader id={album.coverArt} type="album">
-                      {(src) => (
-                        <PreviewCard.Image src={src} alt={album.name} />
-                      )}
-                    </ImageLoader>
-                    <PreviewCard.PlayButton
-                      onClick={() => handlePlayAlbum(album)}
-                    />
-                  </PreviewCard.ImageWrapper>
-                  <PreviewCard.InfoWrapper>
-                    <PreviewCard.Title link={ROUTES.ALBUM.PAGE(album.id)}>
-                      {album.name}
-                    </PreviewCard.Title>
-                    <PreviewCard.Subtitle
-                      enableLink={album.artistId !== undefined}
-                      link={ROUTES.ARTIST.PAGE(album.artistId ?? '')}
+            {list.map((album, index) => {
+              const isAlbumActive =
+                source?.type === 'album' && source.id === album.id
+              const isAlbumPlaying = isAlbumActive && isPlaying
+              return (
+                <CarouselItem
+                  key={album.id}
+                  className="basis-1/6 2xl:basis-1/8"
+                  data-testid={`preview-list-carousel-item-${index}`}
+                >
+                  <PreviewCard.Root>
+                    <PreviewCard.ImageWrapper
+                      link={ROUTES.ALBUM.PAGE(album.id)}
                     >
-                      {album.artist}
-                    </PreviewCard.Subtitle>
-                  </PreviewCard.InfoWrapper>
-                </PreviewCard.Root>
-              </CarouselItem>
-            ))}
+                      <ImageLoader id={album.coverArt} type="album">
+                        {(src) => (
+                          <PreviewCard.Image src={src} alt={album.name} />
+                        )}
+                      </ImageLoader>
+                      {!isAlbumPlaying && (
+                        <PreviewCard.PlayButton
+                          onClick={() => handlePlayAlbum(album)}
+                          isActive={isAlbumActive}
+                        />
+                      )}
+                      {isAlbumPlaying && (
+                        <PreviewCard.PauseButton
+                          isActive={isAlbumActive}
+                          onClick={togglePlayPause}
+                        />
+                      )}
+                    </PreviewCard.ImageWrapper>
+                    <PreviewCard.InfoWrapper>
+                      <PreviewCard.Title link={ROUTES.ALBUM.PAGE(album.id)}>
+                        {album.name}
+                      </PreviewCard.Title>
+                      <PreviewCard.Subtitle
+                        enableLink={album.artistId !== undefined}
+                        link={ROUTES.ARTIST.PAGE(album.artistId ?? '')}
+                      >
+                        {album.artist}
+                      </PreviewCard.Subtitle>
+                    </PreviewCard.InfoWrapper>
+                  </PreviewCard.Root>
+                </CarouselItem>
+              )
+            })}
           </CarouselContent>
         </Carousel>
       </div>

--- a/src/app/components/playlist/buttons.tsx
+++ b/src/app/components/playlist/buttons.tsx
@@ -1,6 +1,10 @@
 import { useTranslation } from 'react-i18next'
 import { Actions } from '@/app/components/actions'
-import { usePlayerActions } from '@/store/player.store'
+import {
+  usePlayerActions,
+  usePlayerContext,
+  usePlayerStore,
+} from '@/store/player.store'
 import { PlaylistWithEntries } from '@/types/responses/playlist'
 import { PlaylistOptions } from './options'
 
@@ -10,29 +14,64 @@ interface PlaylistButtonsProps {
 
 export function PlaylistButtons({ playlist }: PlaylistButtonsProps) {
   const { t } = useTranslation()
-  const { setSongList } = usePlayerActions()
+  const { setSongList, togglePlayPause } = usePlayerActions()
+  const { source } = usePlayerContext()
+  const isPlaying = usePlayerStore((state) => state.playerState.isPlaying)
+  const isShuffleActive = usePlayerStore(
+    (state) => state.playerState.isShuffleActive,
+  )
 
   const buttonsTooltips = {
     play: t('playlist.buttons.play', { name: playlist.name }),
     shuffle: t('playlist.buttons.shuffle', { name: playlist.name }),
     options: t('playlist.buttons.options', { name: playlist.name }),
+    pause: t('playlist.buttons.pause', { name: playlist.name }),
   }
+
+  const isPlaylistActive =
+    source?.type === 'playlist' && source.id === playlist.id
+  const isPlaylistPlaying = isPlaylistActive && isPlaying
 
   return (
     <Actions.Container>
-      <Actions.Button
-        tooltip={buttonsTooltips.play}
-        buttonStyle="primary"
-        onClick={() => setSongList(playlist.entry, 0)}
-        disabled={!playlist.entry}
-      >
-        <Actions.PlayIcon />
-      </Actions.Button>
+      {isPlaylistPlaying && (
+        <Actions.Button
+          tooltip={buttonsTooltips.pause}
+          buttonStyle="primary"
+          onClick={togglePlayPause}
+          disabled={!playlist.entry}
+        >
+          <Actions.PauseIcon />
+        </Actions.Button>
+      )}
+      {!isPlaylistPlaying && (
+        <Actions.Button
+          tooltip={buttonsTooltips.play}
+          buttonStyle="primary"
+          onClick={() =>
+            setSongList(playlist.entry, 0, false, {
+              id: playlist.id,
+              name: playlist.name,
+              type: 'playlist',
+            })
+          }
+          disabled={!playlist.entry}
+        >
+          <Actions.PlayIcon />
+        </Actions.Button>
+      )}
 
       <Actions.Button
         tooltip={buttonsTooltips.shuffle}
-        onClick={() => setSongList(playlist.entry, 0, true)}
+        onClick={() =>
+          setSongList(playlist.entry, 0, true, {
+            id: playlist.id,
+            name: playlist.name,
+            type: 'playlist',
+          })
+        }
         disabled={!playlist.entry}
+        isActive={isPlaylistPlaying && isShuffleActive}
       >
         <Actions.ShuffleIcon />
       </Actions.Button>

--- a/src/app/components/preview-card/card.cy.tsx
+++ b/src/app/components/preview-card/card.cy.tsx
@@ -54,7 +54,7 @@ describe('PreviewCard Component', () => {
                   />
                 )}
               </ImageLoader>
-              <PreviewCard.PlayButton onClick={onClickSpy} />
+              <PreviewCard.PlayButton onClick={onClickSpy} isActive={false} />
             </PreviewCard.ImageWrapper>
           </PreviewCard.Root>
         </Wrapper>,

--- a/src/app/components/preview-card/card.tsx
+++ b/src/app/components/preview-card/card.tsx
@@ -1,5 +1,6 @@
-import { Play } from 'lucide-react'
-import { ComponentPropsWithoutRef } from 'react'
+import clsx from 'clsx'
+import { Pause, Play } from 'lucide-react'
+import React, { ComponentPropsWithoutRef } from 'react'
 import { LazyLoadImage } from 'react-lazy-load-image-component'
 import { Link } from 'react-router-dom'
 import { Button } from '@/app/components/ui/button'
@@ -56,26 +57,65 @@ function Image({ src, alt }: ImageProps) {
   )
 }
 
-interface PlayButtonProps {
+interface ButtonWrapProps extends React.PropsWithChildren {
   onClick: () => void
+  dataTestId: string
+  isActive: boolean
 }
 
-function PlayButton({ onClick }: PlayButtonProps) {
+function ButtonWrap({
+  onClick,
+  dataTestId,
+  children,
+  isActive,
+}: ButtonWrapProps) {
   return (
     <div className="w-full h-full flex items-center justify-center rounded bg-black bg-opacity-0 group-hover:bg-opacity-50 transition-all duration-300 absolute inset-0 z-10">
       <Button
-        className="opacity-0 group-hover:opacity-100 transition-all duration-300 rounded-full w-12 h-12 z-20"
+        className={clsx(
+          'transition-all duration-300 rounded-full w-12 h-12 z-20',
+          !isActive && 'opacity-0 group-hover:opacity-100',
+        )}
         variant="outline"
         onClick={(e) => {
           e.stopPropagation()
           e.preventDefault()
           onClick()
         }}
-        data-testid="card-play-button"
+        data-testid={dataTestId}
       >
-        <Play className="fill-foreground" />
+        {children}
       </Button>
     </div>
+  )
+}
+
+interface PlayPauseButtonProps {
+  onClick: () => void
+  isActive: boolean
+}
+
+function PlayButton({ onClick, isActive }: PlayPauseButtonProps) {
+  return (
+    <ButtonWrap
+      dataTestId="card-play-button"
+      onClick={onClick}
+      isActive={isActive}
+    >
+      <Play className="fill-foreground" />
+    </ButtonWrap>
+  )
+}
+
+function PauseButton({ onClick, isActive }: PlayPauseButtonProps) {
+  return (
+    <ButtonWrap
+      dataTestId="card-pause-button"
+      onClick={onClick}
+      isActive={isActive}
+    >
+      <Pause className="fill-foreground" />
+    </ButtonWrap>
   )
 }
 
@@ -157,4 +197,5 @@ export const PreviewCard = {
   InfoWrapper,
   Title,
   Subtitle,
+  PauseButton,
 }

--- a/src/app/components/queue/song-list.tsx
+++ b/src/app/components/queue/song-list.tsx
@@ -8,17 +8,32 @@ import { Separator } from '@/app/components/ui/separator'
 import { queueColumns } from '@/app/tables/queue-columns'
 import {
   usePlayerActions,
+  usePlayerContext,
   usePlayerCurrentList,
   usePlayerCurrentSongIndex,
 } from '@/store/player.store'
 import { ColumnFilter } from '@/types/columnFilter'
+import { PlaybackSource } from '@/types/playerContext'
 import { convertSecondsToHumanRead } from '@/utils/convertSecondsToTime'
+
+function getSourceLabel(source: PlaybackSource | null): string | null {
+  if (
+    source?.type === 'album' ||
+    source?.type === 'playlist' ||
+    source?.type === 'artist' ||
+    source?.type === 'favourite'
+  ) {
+    return `: ${source.name}`
+  }
+  return null
+}
 
 export function QueueSongList() {
   const { t } = useTranslation()
   const currentList = usePlayerCurrentList()
   const currentSongIndex = usePlayerCurrentSongIndex()
   const { clearPlayerState, setSongList } = usePlayerActions()
+  const { source } = usePlayerContext()
 
   const columns = useMemo(() => queueColumns(), [])
   const trackListCount = useMemo(() => currentList.length, [currentList])
@@ -39,12 +54,17 @@ export function QueueSongList() {
     'remove',
   ]
 
+  const sourceLabel = getSourceLabel(source)
+
   return (
     <div className="flex flex-1 flex-col h-full min-w-[300px]">
       <DialogTitle className="sr-only">{t('queue.title')}</DialogTitle>
       <div className="flex items-center justify-between h-8 mb-2">
         <div className="flex gap-2 h-6 items-center text-foreground/70">
-          <p className="text-foreground">{t('queue.title')}</p>
+          <p className="text-foreground">
+            {t('queue.title')}
+            {sourceLabel}
+          </p>
           <p>{'•'}</p>
           <p className="text-sm">
             {t('playlist.songCount', { count: trackListCount })}

--- a/src/app/components/sidebar/nav-playlists.tsx
+++ b/src/app/components/sidebar/nav-playlists.tsx
@@ -10,11 +10,14 @@ import {
 } from '@/app/components/ui/main-sidebar'
 import { ScrollArea } from '@/app/components/ui/scroll-area'
 import { subsonic } from '@/service/subsonic'
+import { usePlayerContext, usePlayerStore } from '@/store/player.store'
 import { queryKeys } from '@/utils/queryKeys'
 import { SidebarPlaylistItem } from './playlist-item'
 
 export function NavPlaylists() {
   const { t } = useTranslation()
+  const { source } = usePlayerContext()
+  const isPlaying = usePlayerStore((state) => state.playerState.isPlaying)
 
   const { data: playlists } = useQuery({
     queryKey: [queryKeys.playlist.all],
@@ -22,6 +25,7 @@ export function NavPlaylists() {
   })
 
   const hasPlaylists = playlists !== undefined && playlists.length > 0
+  const isAnyPlaylistActive = source?.type === 'playlist'
 
   return (
     <>
@@ -46,9 +50,17 @@ export function NavPlaylists() {
         <ScrollArea className="pb-4">
           <MainSidebarMenu className="pr-4">
             {hasPlaylists &&
-              playlists.map((playlist) => (
-                <SidebarPlaylistItem key={playlist.id} playlist={playlist} />
-              ))}
+              playlists.map((playlist) => {
+                const isPlaylistActive =
+                  isAnyPlaylistActive && source?.id === playlist.id
+                return (
+                  <SidebarPlaylistItem
+                    key={playlist.id}
+                    playlist={playlist}
+                    isPlaying={isPlaylistActive && isPlaying}
+                  />
+                )
+              })}
 
             {!hasPlaylists && <EmptyPlaylistsMessage />}
           </MainSidebarMenu>

--- a/src/app/components/sidebar/playlist-item.tsx
+++ b/src/app/components/sidebar/playlist-item.tsx
@@ -11,11 +11,18 @@ import {
 import { useRouteIsActive } from '@/app/hooks/use-route-is-active'
 import { ROUTES } from '@/routes/routesList'
 import { Playlist } from '@/types/responses/playlist'
+import { EqualizerBars } from '../icons/equalizer-bars'
 
 const MemoContextMenuProvider = memo(ContextMenuProvider)
 const MemoPlaylistOptions = memo(PlaylistOptions)
 
-export function SidebarPlaylistItem({ playlist }: { playlist: Playlist }) {
+export function SidebarPlaylistItem({
+  playlist,
+  isPlaying,
+}: {
+  playlist: Playlist
+  isPlaying: boolean
+}) {
   const { isOnPlaylist } = useRouteIsActive()
 
   return (
@@ -32,7 +39,9 @@ export function SidebarPlaylistItem({ playlist }: { playlist: Playlist }) {
         <MainSidebarMenuButton
           asChild
           className={clsx(
-            isOnPlaylist(playlist.id) && 'cursor-default bg-accent',
+            isOnPlaylist(playlist.id) && 'cursor-default',
+            isOnPlaylist(playlist.id) && !isPlaying && 'bg-accent',
+            isPlaying && 'text-primary',
           )}
         >
           <Link
@@ -43,7 +52,11 @@ export function SidebarPlaylistItem({ playlist }: { playlist: Playlist }) {
               }
             }}
           >
-            <ListMusic />
+            {isPlaying ? (
+              <EqualizerBars className="text-primary" />
+            ) : (
+              <ListMusic />
+            )}
             <span className="truncate">{playlist.name}</span>
           </Link>
         </MainSidebarMenuButton>

--- a/src/app/components/table/play-button.tsx
+++ b/src/app/components/table/play-button.tsx
@@ -3,6 +3,7 @@ import { EqualizerBars } from '@/app/components/icons/equalizer-bars'
 import { Button } from '@/app/components/ui/button'
 import {
   usePlayerActions,
+  usePlayerContext,
   usePlayerIsPlaying,
   usePlayerMediaType,
   usePlayerSonglist,
@@ -23,9 +24,16 @@ export default function PlaySongButton({
   const { isSong, isRadio } = usePlayerMediaType()
   const isPlaying = usePlayerIsPlaying()
   const { radioList, currentSongIndex } = usePlayerSonglist()
+  const { source } = usePlayerContext()
 
   const isCurrentSongPlaying = () => {
     if (isSong) {
+      if (source?.type === 'artist' && source.id === trackId) {
+        return true
+      }
+      if (source?.type === 'playlist' && source.id === trackId) {
+        return true
+      }
       return checkActiveSong(trackId)
     }
     if (isRadio) {

--- a/src/app/pages/albums/album.tsx
+++ b/src/app/pages/albums/album.tsx
@@ -135,7 +135,13 @@ export default function Album() {
         <DataTable
           columns={columns}
           data={album.song}
-          handlePlaySong={(row) => setSongList(album.song, row.index)}
+          handlePlaySong={(row) =>
+            setSongList(album.song, row.index, false, {
+              id: album.id,
+              name: album.name,
+              type: 'album',
+            })
+          }
           columnFilter={columnsToShow}
           showDiscNumber={true}
           variant="modern"

--- a/src/app/pages/artists/list.tsx
+++ b/src/app/pages/artists/list.tsx
@@ -44,7 +44,12 @@ export default function ArtistsList() {
   async function handlePlayArtistRadio(artist: ISimilarArtist) {
     const songList = await getArtistAllSongs(artist.name)
 
-    if (songList) setSongList(songList, 0)
+    if (songList)
+      setSongList(songList, 0, false, {
+        id: artist.id,
+        name: artist.name,
+        type: 'artist',
+      })
   }
 
   if (isLoading) return <ArtistsFallback />

--- a/src/app/pages/favorites/songlist.tsx
+++ b/src/app/pages/favorites/songlist.tsx
@@ -24,7 +24,13 @@ export default function SongList() {
   const songCount = data.songs.length
 
   function handlePlaySong(index: number) {
-    if (songlist) setSongList(songlist, index)
+    if (songlist) {
+      setSongList(songlist, index, false, {
+        type: 'favourite',
+        id: 'favourite',
+        name: t('sidebar.favorites'),
+      })
+    }
   }
 
   const columnsToShow: ColumnFilter[] = [

--- a/src/app/pages/playlists/list.tsx
+++ b/src/app/pages/playlists/list.tsx
@@ -32,7 +32,11 @@ export default function PlaylistsPage() {
     const playlist = await subsonic.playlists.getOne(playlistId)
 
     if (playlist && playlist.entry.length > 0) {
-      setSongList(playlist.entry, 0)
+      setSongList(playlist.entry, 0, false, {
+        id: playlist.id,
+        name: playlist.name,
+        type: 'playlist',
+      })
     }
   }
 

--- a/src/app/pages/playlists/playlist.tsx
+++ b/src/app/pages/playlists/playlist.tsx
@@ -85,7 +85,9 @@ export default function Playlist() {
         <DataTable
           columns={columns}
           data={playlist.entry ?? []}
-          handlePlaySong={(row) => setSongList(playlist.entry, row.index)}
+          handlePlaySong={(row) => {
+            setSongList(playlist.entry, row.index)
+          }}
           columnFilter={columnsToShow}
           noRowsMessage={t('playlist.noSongList')}
           variant="modern"

--- a/src/app/pages/playlists/playlist.tsx
+++ b/src/app/pages/playlists/playlist.tsx
@@ -86,7 +86,11 @@ export default function Playlist() {
           columns={columns}
           data={playlist.entry ?? []}
           handlePlaySong={(row) => {
-            setSongList(playlist.entry, row.index)
+            setSongList(playlist.entry, row.index, false, {
+              id: playlist.id,
+              name: playlist.name,
+              type: 'playlist',
+            })
           }}
           columnFilter={columnsToShow}
           noRowsMessage={t('playlist.noSongList')}

--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -59,6 +59,10 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
             currentPlaybackRate: 1,
             hasPrev: false,
             hasNext: false,
+            playbackContext: {
+              isSourceModified: false,
+              source: null,
+            },
           },
           fullscreen: {
             isFullscreen: false,
@@ -176,7 +180,12 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
             },
           },
           actions: {
-            setSongList: (songlist, index, shuffle = false) => {
+            setSongList: (
+              songlist,
+              index,
+              shuffle = false,
+              playbackSource = null,
+            ) => {
               const { currentList, currentSongIndex } = get().songlist
 
               const listsAreEqual = areSongListsEqual(currentList, songlist)
@@ -185,6 +194,10 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
               get().actions.resetAccumulatedTime()
               get().actions.setHasSyncedTheCurrentTrack(false)
               get().actions.setHasScrobbledTheCurrentTrack(false)
+
+              set((state) => {
+                state.playerState.playbackContext.source = playbackSource
+              })
 
               if (!listsAreEqual || (listsAreEqual && songHasChanged)) {
                 get().actions.resetProgress()
@@ -566,6 +579,7 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
                 state.playerState.audioPlayerRef = null
                 state.settings.colors.currentSongColor = null
                 state.listenTime.accumulated = 0
+                state.playerState.playbackContext.source = null
               })
             },
             resetProgress: () => {
@@ -1290,3 +1304,6 @@ export const usePlayerCurrentList = () =>
 
 export const usePlayerFullscreen = () =>
   usePlayerStore((state) => state.fullscreen)
+
+export const usePlayerContext = () =>
+  usePlayerStore((state) => state.playerState.playbackContext)

--- a/src/types/playerContext.ts
+++ b/src/types/playerContext.ts
@@ -20,6 +20,17 @@ export interface ISongList {
   podcastListProgresses: number[]
 }
 
+export type PlaybackSource =
+  | { type: 'playlist'; id: string; name: string }
+  | { type: 'album'; id: string; name: string }
+  | { type: 'artist'; id: string; name: string }
+  | { type: 'favourite'; id: string; name: string }
+
+export interface IPlaybackContext {
+  source: PlaybackSource | null
+  isSourceModified: boolean
+}
+
 export interface IPlayerState {
   isPlaying: boolean
   loopState: LoopState
@@ -37,6 +48,7 @@ export interface IPlayerState {
   hasScrobbledTheCurrentTrack: boolean
   hasPrev: boolean
   hasNext: boolean
+  playbackContext: IPlaybackContext
 }
 
 export interface IPlayerProgress {
@@ -142,7 +154,12 @@ export interface IPlayerFullscreen {
 
 export interface IPlayerActions {
   playSong: (song: ISong) => void
-  setSongList: (songlist: ISong[], index: number, shuffle?: boolean) => void
+  setSongList: (
+    songlist: ISong[],
+    index: number,
+    shuffle?: boolean,
+    playbackSource?: PlaybackSource | null,
+  ) => void
   setCurrentSong: () => void
   checkIsSongStarred: () => void
   starSongInQueue: (id: string) => void


### PR DESCRIPTION
Currently, when playback is started from a playlist/album/artist in library views, there is no visual feedback indicating which source initiated playback; it often means the play button stays the play button instead of the pause button. 
This PR introduces a playback source context and uses it to visually indicate the currently playing source in playlists (both playlists list and sidebar), album lists, album detail views, artist lists, artist details, and favorites. This behavior is consistent with streaming service apps, and I think it's a nice UX improvement. 

Changes:
- adds `playbackContext.source` to the store;
- `songList` remains unchanged;
- source is set when playback starts from a library object;
- UI highlights the active source across views;
- adds `playbackContext.isSourceModified` if any indication of a modified queue is needed

See attached screenshots:
<img width="1057" height="634" alt="image" src="https://github.com/user-attachments/assets/4df9eb53-07c5-4c4b-a36e-a0e7a9eab9e8" />
<img width="1717" height="745" alt="image" src="https://github.com/user-attachments/assets/72c3f4a0-c227-476a-b4b0-c86e59be339f" />
<img width="1084" height="574" alt="image" src="https://github.com/user-attachments/assets/ec54a337-fb6c-4b5f-923c-84a1b4f7e0fc" />
<img width="1311" height="816" alt="image" src="https://github.com/user-attachments/assets/2fa1938a-fead-4fa5-9c0c-5e6353d2489e" />

