### PR TITLE
feat: add animated artwork covers

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
     "fast-average-color": "^9.5.0",
+    "hls.js": "^1.6.15",
     "html-to-text": "^9.0.5",
     "i18next": "^23.16.8",
     "i18next-browser-languagedetector": "^8.0.4",
@@ -139,7 +140,11 @@
     "vite": "^7.3.1"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["cypress", "electron", "esbuild"],
+    "onlyBuiltDependencies": [
+      "cypress",
+      "electron",
+      "esbuild"
+    ],
     "overrides": {
       "brace-expansion": "^2.0.2",
       "glob": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       fast-average-color:
         specifier: ^9.5.0
         version: 9.5.0
+      hls.js:
+        specifier: ^1.6.15
+        version: 1.6.15
       html-to-text:
         specifier: ^9.0.5
         version: 9.0.5
@@ -289,7 +292,7 @@ importers:
         version: 40.1.0
       electron-builder:
         specifier: ^26.4.0
-        version: 26.4.0(electron-builder-squirrel-windows@26.0.12)
+        version: 26.4.0(electron-builder-squirrel-windows@26.4.0)
       electron-vite:
         specifier: ^5.0.0
         version: 5.0.0(vite@7.3.1(@types/node@22.14.0)(jiti@2.6.1)(terser@5.39.0)(yaml@2.7.1))
@@ -528,11 +531,6 @@ packages:
     peerDependencies:
       electron: '>=13.0.0'
 
-  '@electron/asar@3.2.18':
-    resolution: {integrity: sha512-2XyvMe3N3Nrs8cV39IKELRHTYUWFKrmqqSY1U+GMlc0jvqjIVnoxhNd2H4JolWQncbJi1DCvb5TNxZuI2fEjWg==}
-    engines: {node: '>=10.12.0'}
-    hasBin: true
-
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
     engines: {node: '>=10.12.0'}
@@ -546,39 +544,19 @@ packages:
     resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
     engines: {node: '>=12'}
 
-  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
-    version: 10.2.0-electron.1
-    engines: {node: '>=12.13.0'}
-    hasBin: true
-
   '@electron/notarize@2.5.0':
     resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
     engines: {node: '>= 10.0.0'}
-
-  '@electron/osx-sign@1.3.1':
-    resolution: {integrity: sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
 
   '@electron/osx-sign@1.3.3':
     resolution: {integrity: sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==}
     engines: {node: '>=12.0.0'}
     hasBin: true
 
-  '@electron/rebuild@3.7.0':
-    resolution: {integrity: sha512-VW++CNSlZwMYP7MyXEbrKjpzEwhB5kDNbzGtiPEjwYysqyTCF+YbNJ210Dj3AjWsGSV4iEEwNkmJN9yGZmVvmw==}
-    engines: {node: '>=12.13.0'}
-    hasBin: true
-
   '@electron/rebuild@4.0.1':
     resolution: {integrity: sha512-iMGXb6Ib7H/Q3v+BKZJoETgF9g6KMNZVbsO4b7Dmpgb5qTFqyFTzqW9F3TOSHdybv2vKYKzSS9OiZL+dcJb+1Q==}
     engines: {node: '>=22.12.0'}
     hasBin: true
-
-  '@electron/universal@2.0.1':
-    resolution: {integrity: sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==}
-    engines: {node: '>=16.4'}
 
   '@electron/universal@2.0.3':
     resolution: {integrity: sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==}
@@ -916,9 +894,6 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@gar/promisify@1.1.3':
-    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
-
   '@hookform/resolvers@3.10.0':
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
     peerDependencies:
@@ -1000,18 +975,9 @@ packages:
     resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  '@npmcli/fs@2.1.2':
-    resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-
   '@npmcli/fs@4.0.0':
     resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
-
-  '@npmcli/move-file@2.0.1':
-    resolution: {integrity: sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This functionality has been moved to @npmcli/fs
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1811,10 +1777,6 @@ packages:
   '@tanstack/virtual-core@3.13.6':
     resolution: {integrity: sha512-cnQUeWnhNP8tJ4WsGcYiX24Gjkc9ALstLbHcBj1t3E7EimN6n6kHH+DPV4PpDnuw00NApQp+ViojMj1GRdwYQg==}
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
-    engines: {node: '>= 10'}
-
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1943,9 +1905,6 @@ packages:
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
 
-  abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
-
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -1955,17 +1914,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
 
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -2023,13 +1974,6 @@ packages:
 
   app-builder-bin@5.0.0-alpha.12:
     resolution: {integrity: sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==}
-
-  app-builder-lib@26.0.12:
-    resolution: {integrity: sha512-+/CEPH1fVKf6HowBUs6LcAIoRcjeqgvAeoSE+cl7Y7LndyQ9ViGPYibNk7wmhMHzNgHIuIbw4nWADPO+4mjgWw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      dmg-builder: 26.0.12
-      electron-builder-squirrel-windows: 26.0.12
 
   app-builder-lib@26.4.0:
     resolution: {integrity: sha512-Uas6hNe99KzP3xPWxh5LGlH8kWIVjZixzmMJHNB9+6hPyDpjc7NQMkVgi16rQDdpCFy22ZU5sp8ow7tvjeMgYQ==}
@@ -2162,16 +2106,9 @@ packages:
     resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
     engines: {node: '>=6.14.2'}
 
-  builder-util-runtime@9.3.1:
-    resolution: {integrity: sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==}
-    engines: {node: '>=12.0.0'}
-
   builder-util-runtime@9.5.1:
     resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
     engines: {node: '>=12.0.0'}
-
-  builder-util@26.0.11:
-    resolution: {integrity: sha512-xNjXfsldUEe153h1DraD0XvDOpqGR0L5eKFkdReB7eFW5HqysDZFfly4rckda6y9dF39N3pkPlOblcfHKGw+uA==}
 
   builder-util@26.3.4:
     resolution: {integrity: sha512-aRn88mYMktHxzdqDMF6Ayj0rKoX+ZogJ75Ck7RrIqbY/ad0HBvnS2xA4uHfzrGr5D2aLL3vU6OBEH4p0KMV2XQ==}
@@ -2179,10 +2116,6 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
-
-  cacache@16.1.3:
-    resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   cacache@19.0.1:
     resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
@@ -2244,20 +2177,12 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
-
-  ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
 
   ci-info@4.3.1:
     resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
@@ -2361,9 +2286,6 @@ packages:
   conf@15.0.2:
     resolution: {integrity: sha512-JBSrutapCafTrddF9dH3lc7+T2tBycGF4uPkI4Js+g4vLLEhG6RZcFi3aJd5zntdf5tQxAejJt8dihkoQ/eSJw==}
     engines: {node: '>=20'}
-
-  config-file-ts@0.2.8-rc1:
-    resolution: {integrity: sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2550,8 +2472,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-builder-squirrel-windows@26.0.12:
-    resolution: {integrity: sha512-kpwXM7c/ayRUbYVErQbsZ0nQZX4aLHQrPEG9C4h9vuJCXylwFH8a7Jgi2VpKIObzCXO7LKHiCw4KdioFLFOgqA==}
+  electron-builder-squirrel-windows@26.4.0:
+    resolution: {integrity: sha512-7dvalY38xBzWNaoOJ4sqy2aGIEpl2S1gLPkkB0MHu1Hu5xKQ82il1mKSFlXs6fLpXUso/NmyjdHGlSHDRoG8/w==}
 
   electron-builder@26.4.0:
     resolution: {integrity: sha512-FCUqvdq2AULL+Db2SUGgjOYTbrgkPxZtCjqIZGnjH9p29pTWyesQqBIfvQBKa6ewqde87aWl49n/WyI/NyUBog==}
@@ -2561,9 +2483,6 @@ packages:
   electron-dl@4.0.0:
     resolution: {integrity: sha512-USiB9816d2JzKv0LiSbreRfTg5lDk3lWh0vlx/gugCO92ZIJkHVH0UM18EHvKeadErP6Xn4yiTphWzYfbA2Ong==}
     engines: {node: '>=18'}
-
-  electron-publish@26.0.11:
-    resolution: {integrity: sha512-a8QRH0rAPIWH9WyyS5LbNvW9Ark6qe63/LqDB7vu2JXYpi0Gma5Q60Dh4tmTqhOBQt0xsrzD8qE7C+D7j+B24A==}
 
   electron-publish@26.3.4:
     resolution: {integrity: sha512-5/ouDPb73SkKuay2EXisPG60LTFTMNHWo2WLrK5GDphnWK9UC+yzYrzVeydj078Yk4WUXi0+TaaZsNd6Zt5k/A==}
@@ -2824,10 +2743,6 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-
   fs-minipass@3.0.3:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -2947,6 +2862,9 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  hls.js@1.6.15:
+    resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -2970,10 +2888,6 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
-  http-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
-    engines: {node: '>= 6'}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -2986,10 +2900,6 @@ packages:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
 
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
-
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -2997,9 +2907,6 @@ packages:
   human-signals@1.1.1:
     resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
     engines: {node: '>=8.12.0'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -3038,9 +2945,6 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
-  infer-owner@1.0.4:
-    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -3064,10 +2968,6 @@ packages:
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
-
-  is-ci@3.0.1:
-    resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
-    hasBin: true
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -3098,9 +2998,6 @@ packages:
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
-
-  is-lambda@1.0.1:
-    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -3295,10 +3192,6 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
-
   lucide-react@0.563.0:
     resolution: {integrity: sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==}
     peerDependencies:
@@ -3306,10 +3199,6 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  make-fetch-happen@10.2.1:
-    resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   make-fetch-happen@14.0.3:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
@@ -3513,17 +3402,9 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass-collect@1.0.2:
-    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
-    engines: {node: '>= 8'}
-
   minipass-collect@2.0.1:
     resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minipass-fetch@2.1.2:
-    resolution: {integrity: sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   minipass-fetch@4.0.1:
     resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
@@ -3549,21 +3430,12 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
-
-  mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
     hasBin: true
 
   ms@2.1.3:
@@ -3577,17 +3449,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  negotiator@0.6.4:
-    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
-    engines: {node: '>= 0.6'}
-
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
-
-  node-abi@3.87.0:
-    resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
-    engines: {node: '>=10'}
 
   node-abi@4.26.0:
     resolution: {integrity: sha512-8QwIZqikRvDIkXS2S93LjzhsSPJuIbfaMETWH+Bx8oOT9Sa9UsUtBFQlc3gBNd1+QINjaTloitXr1W3dQLi9Iw==}
@@ -3622,11 +3486,6 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
-
-  nopt@6.0.0:
-    resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    hasBin: true
 
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
@@ -3812,10 +3671,6 @@ packages:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
 
-  proc-log@2.0.1:
-    resolution: {integrity: sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -3827,14 +3682,6 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
-
-  promise-inflight@1.0.1:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
 
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
@@ -4085,11 +3932,6 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   roarr@2.15.4:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
@@ -4191,10 +4033,6 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  socks-proxy-agent@7.0.0:
-    resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
-    engines: {node: '>= 10'}
-
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
@@ -4236,10 +4074,6 @@ packages:
   ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
-
-  ssri@9.0.1:
-    resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   standardized-audio-context@25.3.77:
     resolution: {integrity: sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==}
@@ -4452,11 +4286,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   ua-parser-js@1.0.40:
     resolution: {integrity: sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==}
     hasBin: true
@@ -4477,17 +4306,9 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
-  unique-filename@2.0.1:
-    resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-
   unique-filename@4.0.0:
     resolution: {integrity: sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
-
-  unique-slug@3.0.0:
-    resolution: {integrity: sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   unique-slug@5.0.0:
     resolution: {integrity: sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==}
@@ -5036,12 +4857,6 @@ snapshots:
     dependencies:
       electron: 40.1.0
 
-  '@electron/asar@3.2.18':
-    dependencies:
-      commander: 5.1.0
-      glob: 11.1.0
-      minimatch: 3.1.2
-
   '@electron/asar@3.4.1':
     dependencies:
       commander: 5.1.0
@@ -5068,38 +4883,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    dependencies:
-      env-paths: 2.2.1
-      exponential-backoff: 3.1.3
-      glob: 11.1.0
-      graceful-fs: 4.2.11
-      make-fetch-happen: 10.2.1
-      nopt: 6.0.0
-      proc-log: 2.0.1
-      semver: 7.7.3
-      tar: 7.5.7
-      which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-
   '@electron/notarize@2.5.0':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 9.1.0
       promise-retry: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@electron/osx-sign@1.3.1':
-    dependencies:
-      compare-version: 0.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      fs-extra: 10.1.0
-      isbinaryfile: 4.0.10
-      minimist: 1.2.8
-      plist: 3.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5112,26 +4900,6 @@ snapshots:
       minimist: 1.2.8
       plist: 3.1.0
     transitivePeerDependencies:
-      - supports-color
-
-  '@electron/rebuild@3.7.0':
-    dependencies:
-      '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2
-      '@malept/cross-spawn-promise': 2.0.0
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      detect-libc: 2.1.2
-      fs-extra: 10.1.0
-      got: 11.8.6
-      node-abi: 3.87.0
-      node-api-version: 0.2.1
-      ora: 5.4.1
-      read-binary-file-arch: 1.0.6
-      semver: 7.7.3
-      tar: 7.5.7
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bluebird
       - supports-color
 
   '@electron/rebuild@4.0.1':
@@ -5150,18 +4918,6 @@ snapshots:
       semver: 7.7.3
       tar: 7.5.7
       yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@electron/universal@2.0.1':
-    dependencies:
-      '@electron/asar': 3.4.1
-      '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
-      dir-compare: 4.2.0
-      fs-extra: 11.3.3
-      minimatch: 9.0.5
-      plist: 3.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5361,8 +5117,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@gar/promisify@1.1.3': {}
-
   '@hookform/resolvers@3.10.0(react-hook-form@7.55.0(react@18.3.1))':
     dependencies:
       react-hook-form: 7.55.0(react@18.3.1)
@@ -5462,19 +5216,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@npmcli/fs@2.1.2':
-    dependencies:
-      '@gar/promisify': 1.1.3
-      semver: 7.7.3
-
   '@npmcli/fs@4.0.0':
     dependencies:
       semver: 7.7.3
-
-  '@npmcli/move-file@2.0.1':
-    dependencies:
-      mkdirp: 1.0.4
-      rimraf: 3.0.2
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6206,8 +5950,6 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.6': {}
 
-  '@tootallnate/once@2.0.0': {}
-
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.6
@@ -6360,23 +6102,11 @@ snapshots:
 
   '@xmldom/xmldom@0.8.11': {}
 
-  abbrev@1.1.1: {}
-
   abbrev@3.0.1: {}
 
   acorn@8.14.1: {}
 
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   agent-base@7.1.4: {}
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
 
   aggregate-error@3.1.0:
     dependencies:
@@ -6430,48 +6160,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.12: {}
 
-  app-builder-lib@26.0.12(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.0.12):
-    dependencies:
-      '@develar/schema-utils': 2.6.5
-      '@electron/asar': 3.2.18
-      '@electron/fuses': 1.8.0
-      '@electron/notarize': 2.5.0
-      '@electron/osx-sign': 1.3.1
-      '@electron/rebuild': 3.7.0
-      '@electron/universal': 2.0.1
-      '@malept/flatpak-bundler': 0.4.0
-      '@types/fs-extra': 9.0.13
-      async-exit-hook: 2.0.1
-      builder-util: 26.0.11
-      builder-util-runtime: 9.3.1
-      chromium-pickle-js: 0.2.0
-      config-file-ts: 0.2.8-rc1
-      debug: 4.4.3(supports-color@8.1.1)
-      dmg-builder: 26.4.0(electron-builder-squirrel-windows@26.0.12)
-      dotenv: 16.6.1
-      dotenv-expand: 11.0.7
-      ejs: 3.1.10
-      electron-builder-squirrel-windows: 26.0.12(dmg-builder@26.4.0)
-      electron-publish: 26.0.11
-      fs-extra: 10.1.0
-      hosted-git-info: 4.1.0
-      is-ci: 3.0.1
-      isbinaryfile: 5.0.7
-      js-yaml: 4.1.1
-      json5: 2.2.3
-      lazy-val: 1.0.5
-      minimatch: 10.1.1
-      plist: 3.1.0
-      resedit: 1.7.2
-      semver: 7.7.3
-      tar: 7.5.7
-      temp-file: 3.4.0
-      tiny-async-pool: 1.3.0
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-
-  app-builder-lib@26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.0.12):
+  app-builder-lib@26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/asar': 3.4.1
@@ -6488,11 +6177,11 @@ snapshots:
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
       debug: 4.4.3(supports-color@8.1.1)
-      dmg-builder: 26.4.0(electron-builder-squirrel-windows@26.0.12)
+      dmg-builder: 26.4.0(electron-builder-squirrel-windows@26.4.0)
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 26.0.12(dmg-builder@26.4.0)
+      electron-builder-squirrel-windows: 26.4.0(dmg-builder@26.4.0)
       electron-publish: 26.3.4
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
@@ -6630,39 +6319,10 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
 
-  builder-util-runtime@9.3.1:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      sax: 1.4.4
-    transitivePeerDependencies:
-      - supports-color
-
   builder-util-runtime@9.5.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       sax: 1.4.4
-    transitivePeerDependencies:
-      - supports-color
-
-  builder-util@26.0.11:
-    dependencies:
-      7zip-bin: 5.2.0
-      '@types/debug': 4.1.12
-      app-builder-bin: 5.0.0-alpha.12
-      builder-util-runtime: 9.3.1
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
-      fs-extra: 10.1.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      is-ci: 3.0.1
-      js-yaml: 4.1.1
-      sanitize-filename: 1.6.3
-      source-map-support: 0.5.21
-      stat-mode: 1.0.0
-      temp-file: 3.4.0
-      tiny-async-pool: 1.3.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6688,29 +6348,6 @@ snapshots:
       - supports-color
 
   cac@6.7.14: {}
-
-  cacache@16.1.3:
-    dependencies:
-      '@npmcli/fs': 2.1.2
-      '@npmcli/move-file': 2.0.1
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      glob: 11.1.0
-      infer-owner: 1.0.4
-      lru-cache: 7.18.3
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      mkdirp: 1.0.4
-      p-map: 4.0.0
-      promise-inflight: 1.0.1
-      rimraf: 3.0.2
-      ssri: 9.0.1
-      tar: 7.5.7
-      unique-filename: 2.0.1
-    transitivePeerDependencies:
-      - bluebird
 
   cacache@19.0.1:
     dependencies:
@@ -6786,13 +6423,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chownr@2.0.0: {}
-
   chownr@3.0.0: {}
 
   chromium-pickle-js@0.2.0: {}
-
-  ci-info@3.9.0: {}
 
   ci-info@4.3.1: {}
 
@@ -6890,11 +6523,6 @@ snapshots:
       json-schema-typed: 8.0.2
       semver: 7.7.3
       uint8array-extras: 1.5.0
-
-  config-file-ts@0.2.8-rc1:
-    dependencies:
-      glob: 11.1.0
-      typescript: 5.9.3
 
   convert-source-map@2.0.0: {}
 
@@ -7066,9 +6694,9 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  dmg-builder@26.4.0(electron-builder-squirrel-windows@26.0.12):
+  dmg-builder@26.4.0(electron-builder-squirrel-windows@26.4.0):
     dependencies:
-      app-builder-lib: 26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.0.12)
+      app-builder-lib: 26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0)
       builder-util: 26.3.4
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
@@ -7136,24 +6764,23 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-builder-squirrel-windows@26.0.12(dmg-builder@26.4.0):
+  electron-builder-squirrel-windows@26.4.0(dmg-builder@26.4.0):
     dependencies:
-      app-builder-lib: 26.0.12(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.0.12)
-      builder-util: 26.0.11
+      app-builder-lib: 26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0)
+      builder-util: 26.3.4
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
-      - bluebird
       - dmg-builder
       - supports-color
 
-  electron-builder@26.4.0(electron-builder-squirrel-windows@26.0.12):
+  electron-builder@26.4.0(electron-builder-squirrel-windows@26.4.0):
     dependencies:
-      app-builder-lib: 26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.0.12)
+      app-builder-lib: 26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@26.4.0)
       builder-util: 26.3.4
       builder-util-runtime: 9.5.1
       chalk: 4.1.2
       ci-info: 4.3.1
-      dmg-builder: 26.4.0(electron-builder-squirrel-windows@26.0.12)
+      dmg-builder: 26.4.0(electron-builder-squirrel-windows@26.4.0)
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       simple-update-notifier: 2.0.0
@@ -7167,19 +6794,6 @@ snapshots:
       ext-name: 5.0.0
       pupa: 3.1.0
       unused-filename: 4.0.1
-
-  electron-publish@26.0.11:
-    dependencies:
-      '@types/fs-extra': 9.0.13
-      builder-util: 26.0.11
-      builder-util-runtime: 9.3.1
-      chalk: 4.1.2
-      form-data: 4.0.5
-      fs-extra: 10.1.0
-      lazy-val: 1.0.5
-      mime: 2.6.0
-    transitivePeerDependencies:
-      - supports-color
 
   electron-publish@26.3.4:
     dependencies:
@@ -7518,10 +7132,6 @@ snapshots:
       jsonfile: 6.1.0
       universalify: 2.0.1
 
-  fs-minipass@2.1.0:
-    dependencies:
-      minipass: 3.3.6
-
   fs-minipass@3.0.3:
     dependencies:
       minipass: 7.1.2
@@ -7713,6 +7323,8 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  hls.js@1.6.15: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -7742,14 +7354,6 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
-  http-proxy-agent@5.0.0:
-    dependencies:
-      '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -7768,13 +7372,6 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -7783,10 +7380,6 @@ snapshots:
       - supports-color
 
   human-signals@1.1.1: {}
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
 
   husky@9.1.7: {}
 
@@ -7818,8 +7411,6 @@ snapshots:
 
   indent-string@4.0.0: {}
 
-  infer-owner@1.0.4: {}
-
   inherits@2.0.4: {}
 
   ini@2.0.0: {}
@@ -7838,10 +7429,6 @@ snapshots:
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
-
-  is-ci@3.0.1:
-    dependencies:
-      ci-info: 3.9.0
 
   is-core-module@2.16.1:
     dependencies:
@@ -7865,8 +7452,6 @@ snapshots:
       is-path-inside: 3.0.3
 
   is-interactive@1.0.0: {}
-
-  is-lambda@1.0.1: {}
 
   is-number@7.0.0: {}
 
@@ -8026,8 +7611,6 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  lru-cache@7.18.3: {}
-
   lucide-react@0.563.0(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -8035,28 +7618,6 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  make-fetch-happen@10.2.1:
-    dependencies:
-      agentkeepalive: 4.6.0
-      cacache: 16.1.3
-      http-cache-semantics: 4.2.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-lambda: 1.0.1
-      lru-cache: 7.18.3
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 2.1.2
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      negotiator: 0.6.4
-      promise-retry: 2.0.1
-      socks-proxy-agent: 7.0.0
-      ssri: 9.0.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
 
   make-fetch-happen@14.0.3:
     dependencies:
@@ -8470,21 +8031,9 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass-collect@1.0.2:
-    dependencies:
-      minipass: 3.3.6
-
   minipass-collect@2.0.1:
     dependencies:
       minipass: 7.1.2
-
-  minipass-fetch@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      minipass-sized: 1.0.3
-      minizlib: 2.1.2
-    optionalDependencies:
-      encoding: 0.1.13
 
   minipass-fetch@4.0.1:
     dependencies:
@@ -8512,11 +8061,6 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  minizlib@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.2
@@ -8524,8 +8068,6 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
-
-  mkdirp@1.0.4: {}
 
   ms@2.1.3: {}
 
@@ -8537,13 +8079,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  negotiator@0.6.4: {}
-
   negotiator@1.0.0: {}
-
-  node-abi@3.87.0:
-    dependencies:
-      semver: 7.7.3
 
   node-abi@4.26.0:
     dependencies:
@@ -8582,10 +8118,6 @@ snapshots:
   node-releases@2.0.19: {}
 
   node-releases@2.0.27: {}
-
-  nopt@6.0.0:
-    dependencies:
-      abbrev: 1.1.1
 
   nopt@8.1.0:
     dependencies:
@@ -8750,15 +8282,11 @@ snapshots:
 
   pretty-bytes@5.6.0: {}
 
-  proc-log@2.0.1: {}
-
   proc-log@5.0.0: {}
 
   process@0.11.10: {}
 
   progress@2.0.3: {}
-
-  promise-inflight@1.0.1: {}
 
   promise-retry@2.0.1:
     dependencies:
@@ -9024,10 +8552,6 @@ snapshots:
     dependencies:
       glob: 11.1.0
 
-  rimraf@3.0.2:
-    dependencies:
-      glob: 11.1.0
-
   roarr@2.15.4:
     dependencies:
       boolean: 3.2.0
@@ -9165,14 +8689,6 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socks-proxy-agent@7.0.0:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
-      socks: 2.8.7
-    transitivePeerDependencies:
-      - supports-color
-
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
@@ -9223,10 +8739,6 @@ snapshots:
   ssri@12.0.0:
     dependencies:
       minipass: 7.1.2
-
-  ssri@9.0.1:
-    dependencies:
-      minipass: 3.3.6
 
   standardized-audio-context@25.3.77:
     dependencies:
@@ -9457,8 +8969,6 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typescript@5.9.3: {}
-
   ua-parser-js@1.0.40: {}
 
   uc.micro@2.1.0: {}
@@ -9479,17 +8989,9 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unique-filename@2.0.1:
-    dependencies:
-      unique-slug: 3.0.0
-
   unique-filename@4.0.0:
     dependencies:
       unique-slug: 5.0.0
-
-  unique-slug@3.0.0:
-    dependencies:
-      imurmurhash: 0.1.4
 
   unique-slug@5.0.0:
     dependencies:

--- a/src/api/artworkClient.ts
+++ b/src/api/artworkClient.ts
@@ -1,0 +1,48 @@
+import { useAppStore } from '@/store/app.store'
+
+export const defaultArtworkServiceUrl = 'https://artwork.m8tec.top'
+const artworkSearchPath = '/api/v1/artwork/search'
+
+function getArtworkSearchUrl() {
+  const { customUrlEnabled, baseUrl: configuredBaseUrl } =
+    useAppStore.getState().artwork
+  const baseUrl = customUrlEnabled
+    ? configuredBaseUrl || defaultArtworkServiceUrl
+    : defaultArtworkServiceUrl
+
+  try {
+    return new URL(artworkSearchPath, baseUrl).toString()
+  } catch {
+    return new URL(artworkSearchPath, defaultArtworkServiceUrl).toString()
+  }
+}
+
+function getUrlFromPayload(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null
+  }
+
+  const url = (payload as { url?: unknown }).url
+  return typeof url === 'string' && url.includes('.m3u8') ? url : null
+}
+
+export async function getAnimatedArtworkUrl(
+  artist: string,
+  album: string,
+): Promise<string | null> {
+  try {
+    const query = new URLSearchParams({ artist, album })
+    const searchUrl = getArtworkSearchUrl()
+    const response = await fetch(`${searchUrl}?${query.toString()}`)
+
+    if (!response.ok) {
+      return null
+    }
+
+    const payload = (await response.json()) as unknown
+    return getUrlFromPayload(payload)
+  } catch (error) {
+    console.warn('Unable to fetch animated artwork URL:', error)
+    return null
+  }
+}

--- a/src/app/components/album/animated-cover-video.tsx
+++ b/src/app/components/album/animated-cover-video.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from 'react'
+import { useAnimatedAlbumArtwork } from '@/app/hooks/use-animated-album-artwork'
+import { cn } from '@/lib/utils'
+import { useAppAnimatedCovers } from '@/store/app.store'
+
+type AnimatedCoverScreen = 'album' | 'fullscreen' | 'playerBar'
+
+interface AnimatedCoverVideoProps {
+  artist?: string
+  album?: string
+  className?: string
+  screen?: AnimatedCoverScreen
+}
+
+export function AnimatedCoverVideo({
+  artist,
+  album,
+  className,
+  screen = 'album',
+}: AnimatedCoverVideoProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null)
+  const [hasVideoError, setHasVideoError] = useState(false)
+  const { enabled: globalEnabled, screens } = useAppAnimatedCovers()
+  const isScreenEnabled =
+    screen === 'fullscreen'
+      ? screens.fullscreen
+      : screen === 'playerBar'
+        ? screens.playerBar
+        : screens.album
+  const effectiveEnabled = globalEnabled && isScreenEnabled
+  const { data: streamUrl } = useAnimatedAlbumArtwork(
+    artist,
+    album,
+    effectiveEnabled,
+  )
+
+  useEffect(() => {
+    if (effectiveEnabled && streamUrl) {
+      setHasVideoError(false)
+    }
+  }, [effectiveEnabled, streamUrl])
+
+  useEffect(() => {
+    if (!effectiveEnabled || !streamUrl || !videoRef.current || hasVideoError) {
+      return
+    }
+
+    const video = videoRef.current
+    const canPlayNativeHls =
+      video.canPlayType('application/vnd.apple.mpegurl') !== ''
+    let hlsInstance: { destroy: () => void } | null = null
+    let cancelled = false
+
+    if (canPlayNativeHls) {
+      video.src = streamUrl
+      video.play().catch(() => {
+        setHasVideoError(true)
+      })
+
+      return () => {
+        video.pause()
+        video.removeAttribute('src')
+        video.load()
+      }
+    }
+
+    const attachHls = async () => {
+      const module = await import('hls.js')
+      const Hls = module.default
+
+      if (cancelled) {
+        return
+      }
+
+      if (!videoRef.current || !Hls.isSupported()) {
+        setHasVideoError(true)
+        return
+      }
+
+      const hls = new Hls()
+      hlsInstance = hls
+
+      hls.on(Hls.Events.ERROR, (_, data) => {
+        if (data.fatal) {
+          if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
+            hls.startLoad()
+            return
+          }
+
+          if (data.type === Hls.ErrorTypes.MEDIA_ERROR) {
+            hls.recoverMediaError()
+            return
+          }
+
+          setHasVideoError(true)
+        }
+      })
+
+      hls.loadSource(streamUrl)
+      hls.attachMedia(videoRef.current)
+
+      hls.on(Hls.Events.MANIFEST_PARSED, () => {
+        const currentVideo = videoRef.current
+        if (!currentVideo) {
+          return
+        }
+
+        currentVideo.play().catch(() => {
+          if (cancelled) {
+            return
+          }
+
+          setHasVideoError(true)
+        })
+      })
+    }
+
+    attachHls().catch(() => {
+      if (!cancelled) {
+        setHasVideoError(true)
+      }
+    })
+
+    return () => {
+      cancelled = true
+      hlsInstance?.destroy()
+      video.pause()
+      video.removeAttribute('src')
+      video.load()
+    }
+  }, [streamUrl, hasVideoError, effectiveEnabled])
+
+  if (!effectiveEnabled || !streamUrl || hasVideoError) {
+    return null
+  }
+
+  return (
+    <video
+      ref={videoRef}
+      className={cn('absolute inset-0 w-full h-full object-cover pointer-events-none', className)}
+      muted
+      loop
+      autoPlay
+      playsInline
+      preload="metadata"
+      aria-hidden="true"
+      onError={() => setHasVideoError(true)}
+    />
+  )
+}

--- a/src/app/components/album/animated-cover-video.tsx
+++ b/src/app/components/album/animated-cover-video.tsx
@@ -3,7 +3,7 @@ import { useAnimatedAlbumArtwork } from '@/app/hooks/use-animated-album-artwork'
 import { cn } from '@/lib/utils'
 import { useAppAnimatedCovers } from '@/store/app.store'
 
-type AnimatedCoverScreen = 'album' | 'fullscreen' | 'playerBar'
+type AnimatedCoverScreen = 'album' | 'fullscreen' | 'playerBar' | 'drawer'
 
 interface AnimatedCoverVideoProps {
   artist?: string
@@ -21,12 +21,21 @@ export function AnimatedCoverVideo({
   const videoRef = useRef<HTMLVideoElement | null>(null)
   const [hasVideoError, setHasVideoError] = useState(false)
   const { enabled: globalEnabled, screens } = useAppAnimatedCovers()
-  const isScreenEnabled =
-    screen === 'fullscreen'
-      ? screens.fullscreen
-      : screen === 'playerBar'
-        ? screens.playerBar
-        : screens.album
+
+  const isScreenEnabled = (() => {
+    switch (screen) {
+      case 'fullscreen':
+        return screens.fullscreen
+      case 'playerBar':
+        return screens.playerBar
+      case 'drawer':
+        return screens.drawer
+      case 'album':
+      default:
+        return screens.album
+    }
+  })()
+
   const effectiveEnabled = globalEnabled && isScreenEnabled
   const { data: streamUrl } = useAnimatedAlbumArtwork(
     artist,

--- a/src/app/components/album/image-header.tsx
+++ b/src/app/components/album/image-header.tsx
@@ -6,6 +6,7 @@ import {
   AlbumArtistInfo,
   AlbumMultipleArtistsInfo,
 } from '@/app/components/album/artists'
+import { AnimatedCoverVideo } from '@/app/components/album/animated-cover-video'
 import { ImageHeaderEffect } from '@/app/components/album/header-effect'
 import { AlbumHeaderFallback } from '@/app/components/fallbacks/album-fallbacks'
 import { BadgesData, HeaderInfoGenerator } from '@/app/components/header-info'
@@ -27,6 +28,8 @@ interface ImageHeaderProps {
   coverArtType: CoverArt
   coverArtSize: string
   coverArtAlt: string
+  animatedArtworkArtist?: string
+  animatedArtworkAlbum?: string
   badges: BadgesData
   isPlaylist?: boolean
 }
@@ -41,6 +44,8 @@ export default function ImageHeader({
   coverArtType,
   coverArtSize,
   coverArtAlt,
+  animatedArtworkArtist,
+  animatedArtworkAlbum,
   badges,
   isPlaylist = false,
 }: ImageHeaderProps) {
@@ -101,7 +106,7 @@ export default function ImageHeader({
                 'w-[200px] h-[200px] min-w-[200px] min-h-[200px]',
                 '2xl:w-[250px] 2xl:h-[250px] 2xl:min-w-[250px] 2xl:min-h-[250px]',
                 'bg-skeleton aspect-square bg-cover bg-center rounded',
-                'shadow-header-image overflow-hidden',
+                'shadow-header-image overflow-hidden relative',
                 'hover:scale-[1.02] ease-linear duration-100',
               )}
             >
@@ -118,6 +123,12 @@ export default function ImageHeader({
                 onLoad={handleLoadImage}
                 onError={handleError}
                 onClick={() => setOpen(true)}
+              />
+
+              <AnimatedCoverVideo
+                artist={animatedArtworkArtist}
+                album={animatedArtworkAlbum}
+                screen="album"
               />
             </div>
 

--- a/src/app/components/fullscreen/song-image.tsx
+++ b/src/app/components/fullscreen/song-image.tsx
@@ -1,10 +1,11 @@
 import clsx from 'clsx'
+import { AnimatedCoverVideo } from '@/app/components/album/animated-cover-video'
 import { ImageLoader } from '@/app/components/image-loader'
 import { AspectRatio } from '@/app/components/ui/aspect-ratio'
 import { usePlayerStore } from '@/store/player.store'
 
 export function FullscreenSongImage() {
-  const { coverArt, artist, title } = usePlayerStore(({ songlist }) => {
+  const { coverArt, artist, title, album } = usePlayerStore(({ songlist }) => {
     return songlist.currentSong
   })
 
@@ -14,21 +15,29 @@ export function FullscreenSongImage() {
         ratio={1 / 1}
         className="rounded-lg 2xl:rounded-2xl overflow-hidden bg-accent/60"
       >
-        <ImageLoader id={coverArt} type="song" size={800}>
-          {(src, isLoading) => (
-            <img
-              src={src}
-              alt={`${artist} - ${title}`}
-              className={clsx(
-                'aspect-square object-cover shadow-custom-5 transition-opacity duration-300 opacity-0',
-                'relative after:absolute after:block after:inset-0 after:bg-accent after:text-transparent',
-                !isLoading && 'opacity-100',
-              )}
-              width="100%"
-              height="100%"
-            />
-          )}
-        </ImageLoader>
+        <div className="relative w-full h-full">
+          <ImageLoader id={coverArt} type="song" size={800}>
+            {(src, isLoading) => (
+              <img
+                src={src}
+                alt={`${artist} - ${title}`}
+                className={clsx(
+                  'aspect-square object-cover shadow-custom-5 transition-opacity duration-300 opacity-0',
+                  'relative after:absolute after:block after:inset-0 after:bg-accent after:text-transparent',
+                  !isLoading && 'opacity-100',
+                )}
+                width="100%"
+                height="100%"
+              />
+            )}
+          </ImageLoader>
+
+          <AnimatedCoverVideo
+            artist={artist}
+            album={album}
+            screen="fullscreen"
+          />
+        </div>
       </AspectRatio>
     </div>
   )

--- a/src/app/components/player/track-info.tsx
+++ b/src/app/components/player/track-info.tsx
@@ -76,30 +76,28 @@ export function TrackInfo({ song }: { song: ISong | undefined }) {
         <div className="min-w-[70px] max-w-[70px] aspect-square bg-cover bg-center bg-skeleton rounded overflow-hidden shadow-md relative">
           <ImageLoader id={song.coverArt} type="song" size={400}>
             {(src) => (
-              <>
-                <LazyLoadImage
-                  key={song.id}
-                  id="track-song-image"
-                  src={src}
-                  width="100%"
-                  height="100%"
-                  crossOrigin="anonymous"
-                  effect="opacity"
-                  className="aspect-square object-cover w-full h-full bg-skeleton text-transparent"
-                  data-testid="track-image"
-                  alt={`${song.artist} - ${song.title}`}
-                  onLoad={getImageColor}
-                  onError={handleError}
-                />
-
-                <AnimatedCoverVideo
-                  artist={song.artist}
-                  album={song.album}
-                  screen="playerBar"
-                />
-              </>
+              <LazyLoadImage
+                key={song.id}
+                id="track-song-image"
+                src={src}
+                width="100%"
+                height="100%"
+                crossOrigin="anonymous"
+                effect="opacity"
+                className="aspect-square object-cover w-full h-full bg-skeleton text-transparent"
+                data-testid="track-image"
+                alt={`${song.artist} - ${song.title}`}
+                onLoad={getImageColor}
+                onError={handleError}
+              />
             )}
           </ImageLoader>
+
+          <AnimatedCoverVideo
+            artist={song.artist}
+            album={song.album}
+            screen="playerBar"
+          />
         </div>
       </div>
       <div className="flex flex-col justify-center w-full overflow-hidden">

--- a/src/app/components/player/track-info.tsx
+++ b/src/app/components/player/track-info.tsx
@@ -7,6 +7,7 @@ import { LazyLoadImage } from 'react-lazy-load-image-component'
 import { Link } from 'react-router-dom'
 
 import { MarqueeTitle } from '@/app/components/fullscreen/marquee-title'
+import { AnimatedCoverVideo } from '@/app/components/album/animated-cover-video'
 import { ImageLoader } from '@/app/components/image-loader'
 import { cn } from '@/lib/utils'
 import { ROUTES } from '@/routes/routesList'
@@ -72,23 +73,31 @@ export function TrackInfo({ song }: { song: ISong | undefined }) {
   return (
     <Fragment>
       <div className="group relative">
-        <div className="min-w-[70px] max-w-[70px] aspect-square bg-cover bg-center bg-skeleton rounded overflow-hidden shadow-md">
+        <div className="min-w-[70px] max-w-[70px] aspect-square bg-cover bg-center bg-skeleton rounded overflow-hidden shadow-md relative">
           <ImageLoader id={song.coverArt} type="song" size={400}>
             {(src) => (
-              <LazyLoadImage
-                key={song.id}
-                id="track-song-image"
-                src={src}
-                width="100%"
-                height="100%"
-                crossOrigin="anonymous"
-                effect="opacity"
-                className="aspect-square object-cover w-full h-full bg-skeleton text-transparent"
-                data-testid="track-image"
-                alt={`${song.artist} - ${song.title}`}
-                onLoad={getImageColor}
-                onError={handleError}
-              />
+              <>
+                <LazyLoadImage
+                  key={song.id}
+                  id="track-song-image"
+                  src={src}
+                  width="100%"
+                  height="100%"
+                  crossOrigin="anonymous"
+                  effect="opacity"
+                  className="aspect-square object-cover w-full h-full bg-skeleton text-transparent"
+                  data-testid="track-image"
+                  alt={`${song.artist} - ${song.title}`}
+                  onLoad={getImageColor}
+                  onError={handleError}
+                />
+
+                <AnimatedCoverVideo
+                  artist={song.artist}
+                  album={song.album}
+                  screen="playerBar"
+                />
+              </>
             )}
           </ImageLoader>
         </div>

--- a/src/app/components/queue/current-song-info.tsx
+++ b/src/app/components/queue/current-song-info.tsx
@@ -1,5 +1,6 @@
 import { LazyLoadImage } from 'react-lazy-load-image-component'
 import { Link } from 'react-router-dom'
+import { AnimatedCoverVideo } from '@/app/components/album/animated-cover-video'
 import { ImageLoader } from '@/app/components/image-loader'
 import { LinkWithoutTo } from '@/app/components/song/artist-link'
 import { AspectRatio } from '@/app/components/ui/aspect-ratio'
@@ -19,19 +20,30 @@ export function CurrentSongInfo() {
         ratio={1 / 1}
         className="shadow-header-image rounded-md overflow-hidden bg-accent"
       >
-        <ImageLoader id={currentSong.coverArt} type="song" size={900}>
-          {(src) => (
-            <LazyLoadImage
-              id="song-info-image"
-              src={src}
-              effect="opacity"
-              alt={`${currentSong.artist} - ${currentSong.title}`}
-              className="rounded-md aspect-square object-cover text-transparent"
-              width="100%"
-              height="100%"
-            />
-          )}
-        </ImageLoader>
+        <div className="relative w-full h-full">
+          <ImageLoader id={currentSong.coverArt} type="song" size={900}>
+            {(src) => (
+              <>
+                <LazyLoadImage
+                  id="song-info-image"
+                  src={src}
+                  effect="opacity"
+                  alt={`${currentSong.artist} - ${currentSong.title}`}
+                  className="rounded-md aspect-square object-cover text-transparent"
+                  width="100%"
+                  height="100%"
+                />
+
+                <AnimatedCoverVideo
+                  artist={currentSong.artist}
+                  album={currentSong.album}
+                  screen="drawer"
+                  className="rounded-md"
+                />
+              </>
+            )}
+          </ImageLoader>
+        </div>
       </AspectRatio>
 
       <div className="flex flex-col items-center justify-center mt-6 px-1">

--- a/src/app/components/queue/current-song-info.tsx
+++ b/src/app/components/queue/current-song-info.tsx
@@ -23,26 +23,24 @@ export function CurrentSongInfo() {
         <div className="relative w-full h-full">
           <ImageLoader id={currentSong.coverArt} type="song" size={900}>
             {(src) => (
-              <>
-                <LazyLoadImage
-                  id="song-info-image"
-                  src={src}
-                  effect="opacity"
-                  alt={`${currentSong.artist} - ${currentSong.title}`}
-                  className="rounded-md aspect-square object-cover text-transparent"
-                  width="100%"
-                  height="100%"
-                />
-
-                <AnimatedCoverVideo
-                  artist={currentSong.artist}
-                  album={currentSong.album}
-                  screen="drawer"
-                  className="rounded-md"
-                />
-              </>
+              <LazyLoadImage
+                id="song-info-image"
+                src={src}
+                effect="opacity"
+                alt={`${currentSong.artist} - ${currentSong.title}`}
+                className="rounded-md aspect-square object-cover text-transparent"
+                width="100%"
+                height="100%"
+              />
             )}
           </ImageLoader>
+
+          <AnimatedCoverVideo
+            artist={currentSong.artist}
+            album={currentSong.album}
+            screen="drawer"
+            className="rounded-md"
+          />
         </div>
       </AspectRatio>
 

--- a/src/app/components/settings/pages/privacy/services/animated-covers.tsx
+++ b/src/app/components/settings/pages/privacy/services/animated-covers.tsx
@@ -1,0 +1,159 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import clsx from 'clsx'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { useDebouncedCallback } from 'use-debounce'
+import { z } from 'zod'
+import {
+  ContentItem,
+  ContentItemForm,
+  ContentItemTitle,
+  ContentSeparator,
+} from '@/app/components/settings/section'
+import { Input } from '@/app/components/ui/input'
+import { Switch } from '@/app/components/ui/switch'
+import { useAppAnimatedCovers } from '@/store/app.store'
+
+const formSchema = z.object({
+  baseUrl: z.string().url({ message: 'login.form.validations.url' }).optional(),
+})
+
+type FormSchemaType = z.infer<typeof formSchema>
+
+export function AnimatedCoversSettings() {
+  const { t } = useTranslation()
+  const {
+    enabled,
+    setEnabled,
+    customUrlEnabled,
+    setCustomUrlEnabled,
+    baseUrl,
+    setBaseUrl,
+    screens,
+  } = useAppAnimatedCovers()
+
+  const {
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      baseUrl,
+    },
+  })
+
+  const debounce = useDebouncedCallback((data: Partial<FormSchemaType>) => {
+    if (data.baseUrl !== undefined) {
+      setBaseUrl(data.baseUrl)
+    }
+  }, 500)
+
+  watch((data) => {
+    debounce(data)
+  })
+
+  return (
+    <>
+      <ContentItem>
+        <ContentItemTitle
+          info={t('settings.privacy.services.animatedCover.enabled.info')}
+        >
+          {t('settings.privacy.services.animatedCover.enabled.label')}
+        </ContentItemTitle>
+        <ContentItemForm>
+          <Switch checked={enabled} onCheckedChange={setEnabled} />
+        </ContentItemForm>
+      </ContentItem>
+
+      {enabled && (
+        <ContentItem>
+          <ContentItemTitle
+            info={t('settings.privacy.services.animatedCover.customUrl.info')}
+          >
+            {t('settings.privacy.services.animatedCover.customUrl.toggle')}
+          </ContentItemTitle>
+          <ContentItemForm>
+            <Switch
+              checked={customUrlEnabled}
+              onCheckedChange={setCustomUrlEnabled}
+            />
+          </ContentItemForm>
+        </ContentItem>
+      )}
+
+      {enabled && customUrlEnabled && (
+        <ContentItem>
+          <ContentItemTitle
+            info={t(
+              'settings.privacy.services.animatedCover.customUrl.example',
+            )}
+          >
+            {t('settings.privacy.services.animatedCover.customUrl.label')}
+          </ContentItemTitle>
+          <ContentItemForm>
+            <Input
+              {...register('baseUrl')}
+              className={clsx('h-8', errors.baseUrl && 'border-destructive')}
+              onChange={(e) => {
+                setValue('baseUrl', e.target.value, {
+                  shouldValidate: true,
+                })
+              }}
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              autoComplete="off"
+            />
+          </ContentItemForm>
+        </ContentItem>
+      )}
+
+      <ContentItem>
+        <ContentItemTitle
+          info={t('settings.privacy.services.animatedCover.screens.album.info')}
+        >
+          {t('settings.privacy.services.animatedCover.screens.album.label')}
+        </ContentItemTitle>
+        <ContentItemForm>
+          <Switch checked={screens.album} onCheckedChange={screens.setAlbum} />
+        </ContentItemForm>
+      </ContentItem>
+
+      <ContentItem>
+        <ContentItemTitle
+          info={t(
+            'settings.privacy.services.animatedCover.screens.fullscreen.info',
+          )}
+        >
+          {t('settings.privacy.services.animatedCover.screens.fullscreen.label')}
+        </ContentItemTitle>
+        <ContentItemForm>
+          <Switch
+            checked={screens.fullscreen}
+            onCheckedChange={screens.setFullscreen}
+          />
+        </ContentItemForm>
+      </ContentItem>
+
+      <ContentItem>
+        <ContentItemTitle
+          info={t(
+            'settings.privacy.services.animatedCover.screens.playerBar.info',
+          )}
+        >
+          {t('settings.privacy.services.animatedCover.screens.playerBar.label')}
+        </ContentItemTitle>
+        <ContentItemForm>
+          <Switch
+            checked={screens.playerBar}
+            onCheckedChange={screens.setPlayerBar}
+          />
+        </ContentItemForm>
+      </ContentItem>
+
+      <ContentSeparator className="!mt-3" />
+    </>
+  )
+}

--- a/src/app/components/settings/pages/privacy/services/animated-covers.tsx
+++ b/src/app/components/settings/pages/privacy/services/animated-covers.tsx
@@ -153,6 +153,17 @@ export function AnimatedCoversSettings() {
         </ContentItemForm>
       </ContentItem>
 
+      <ContentItem>
+        <ContentItemTitle
+          info={t('settings.privacy.services.animatedCover.screens.drawer.info')}
+        >
+          {t('settings.privacy.services.animatedCover.screens.drawer.label')}
+        </ContentItemTitle>
+        <ContentItemForm>
+          <Switch checked={screens.drawer} onCheckedChange={screens.setDrawer} />
+        </ContentItemForm>
+      </ContentItem>
+
       <ContentSeparator className="!mt-3" />
     </>
   )

--- a/src/app/components/settings/pages/privacy/services/index.tsx
+++ b/src/app/components/settings/pages/privacy/services/index.tsx
@@ -7,6 +7,7 @@ import {
   HeaderTitle,
   Root,
 } from '@/app/components/settings/section'
+import { AnimatedCoversSettings } from './animated-covers'
 import { LrcLib } from './lrclib'
 
 export function Services() {
@@ -22,6 +23,7 @@ export function Services() {
       </Header>
       <ContentSeparator className="mb-2" />
       <Content>
+        <AnimatedCoversSettings />
         <LrcLib />
       </Content>
     </Root>

--- a/src/app/hooks/use-animated-album-artwork.tsx
+++ b/src/app/hooks/use-animated-album-artwork.tsx
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query'
+import { getAnimatedArtworkUrl } from '@/api/artworkClient'
+import { useAppAnimatedCovers } from '@/store/app.store'
+import { queryKeys } from '@/utils/queryKeys'
+
+export function useAnimatedAlbumArtwork(
+  artist?: string,
+  album?: string,
+  enabled = true,
+) {
+  const { baseUrl, customUrlEnabled } = useAppAnimatedCovers()
+  const normalizedArtist = artist?.trim() || ''
+  const normalizedAlbum = album?.trim() || ''
+  const normalizedBaseUrl = customUrlEnabled
+    ? baseUrl.trim().toLowerCase()
+    : 'default'
+
+  return useQuery({
+    queryKey: [
+      queryKeys.album.animatedArtwork,
+      normalizedArtist.toLowerCase(),
+      normalizedAlbum.toLowerCase(),
+      normalizedBaseUrl,
+    ],
+    queryFn: () => getAnimatedArtworkUrl(normalizedArtist, normalizedAlbum),
+    enabled: enabled && !!normalizedArtist && !!normalizedAlbum,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+    retry: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+  })
+}

--- a/src/app/pages/albums/album.tsx
+++ b/src/app/pages/albums/album.tsx
@@ -126,6 +126,8 @@ export default function Album() {
         coverArtType="album"
         coverArtSize="700"
         coverArtAlt={album.name}
+        animatedArtworkArtist={album.artist}
+        animatedArtworkAlbum={album.name}
         badges={badges}
       />
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -606,6 +606,32 @@
           "customUrl": {
             "toggle": "Benutzerdefinierte URL verwenden"
           }
+        },
+        "animatedCover": {
+          "enabled": {
+            "label": "Animierte Cover aktivieren",
+            "info": "Wenn aktiviert, werden animierte Cover von einem externen Dienst geladen, falls verfügbar."
+          },
+          "customUrl": {
+            "toggle": "Benutzerdefinierte URL verwenden",
+            "info": "Verwende eine benutzerdefinierte URL für die API animierter Cover statt der Standard-URL.",
+            "label": "URL",
+            "example": "Standard: https://artwork.m8tec.top"
+          },
+          "screens": {
+            "album": {
+              "label": "Albumansicht",
+              "info": "Animierte Cover in der Album-Header-Ansicht aktivieren."
+            },
+            "fullscreen": {
+              "label": "Vollbild-Player",
+              "info": "Animierte Cover im Vollbild-Player aktivieren."
+            },
+            "playerBar": {
+              "label": "Untere Player-Leiste",
+              "info": "Animierte Cover für das aktuelle Song-Cover in der unteren Player-Leiste aktivieren."
+            }
+          }
         }
       }
     },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -630,6 +630,10 @@
             "playerBar": {
               "label": "Untere Player-Leiste",
               "info": "Animierte Cover für das aktuelle Song-Cover in der unteren Player-Leiste aktivieren."
+            },
+            "drawer": {
+              "label": "Queue/Lyrics Drawer",
+              "info": "Animierte Cover für das aktuelle Song-Cover im Queue/Lyrics-Drawer aktivieren."
             }
           }
         }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -675,6 +675,32 @@
             "label": "URL",
             "example": "Example: https://my-lrclib.com"
           }
+        },
+        "animatedCover": {
+          "enabled": {
+            "label": "Enable Animated Covers",
+            "info": "When enabled, animated covers will be loaded from an external service when available."
+          },
+          "customUrl": {
+            "toggle": "Use a custom URL",
+            "info": "Use a custom URL for animated artwork API instead of the default one.",
+            "label": "URL",
+            "example": "Default: https://artwork.m8tec.top"
+          },
+          "screens": {
+            "album": {
+              "label": "Album Page",
+              "info": "Enable animated covers in album header view."
+            },
+            "fullscreen": {
+              "label": "Fullscreen Player",
+              "info": "Enable animated covers in fullscreen player cover."
+            },
+            "playerBar": {
+              "label": "Bottom Player Bar",
+              "info": "Enable animated covers for the current-song cover in the bottom player bar."
+            }
+          }
         }
       }
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -699,6 +699,10 @@
             "playerBar": {
               "label": "Bottom Player Bar",
               "info": "Enable animated covers for the current-song cover in the bottom player bar."
+            },
+            "drawer": {
+              "label": "Queue/Lyrics Drawer",
+              "info": "Enable animated covers for the current-song cover in the queue/lyrics drawer."
             }
           }
         }

--- a/src/store/app.store.ts
+++ b/src/store/app.store.ts
@@ -134,6 +134,12 @@ export const useAppStore = createWithEqualityFn<IAppContext>()(
                   state.artwork.screens.playerBar = value
                 })
               },
+              drawer: true,
+              setDrawer: (value) => {
+                set((state) => {
+                  state.artwork.screens.drawer = value
+                })
+              },
             },
           },
           pages: {

--- a/src/store/app.store.ts
+++ b/src/store/app.store.ts
@@ -27,6 +27,8 @@ const {
   IMAGE_CACHE_ENABLED,
 } = window
 
+const defaultArtworkServiceUrl = 'https://artwork.m8tec.top'
+
 export const useAppStore = createWithEqualityFn<IAppContext>()(
   subscribeWithSelector(
     persist(
@@ -92,6 +94,46 @@ export const useAppStore = createWithEqualityFn<IAppContext>()(
               set((state) => {
                 state.podcasts.collapsibleState = value
               })
+            },
+          },
+          artwork: {
+            enabled: false,
+            setEnabled: (value) => {
+              set((state) => {
+                state.artwork.enabled = value
+              })
+            },
+            customUrlEnabled: false,
+            setCustomUrlEnabled: (value) => {
+              set((state) => {
+                state.artwork.customUrlEnabled = value
+              })
+            },
+            baseUrl: defaultArtworkServiceUrl,
+            setBaseUrl: (value) => {
+              set((state) => {
+                state.artwork.baseUrl = value
+              })
+            },
+            screens: {
+              album: true,
+              setAlbum: (value) => {
+                set((state) => {
+                  state.artwork.screens.album = value
+                })
+              },
+              fullscreen: true,
+              setFullscreen: (value) => {
+                set((state) => {
+                  state.artwork.screens.fullscreen = value
+                })
+              },
+              playerBar: true,
+              setPlayerBar: (value) => {
+                set((state) => {
+                  state.artwork.screens.playerBar = value
+                })
+              },
             },
           },
           pages: {
@@ -373,6 +415,7 @@ useAppStore.subscribe(
 export const useAppData = () => useAppStore((state) => state.data)
 export const useAppAccounts = () => useAppStore((state) => state.accounts)
 export const useAppPodcasts = () => useAppStore((state) => state.podcasts)
+export const useAppAnimatedCovers = () => useAppStore((state) => state.artwork)
 export const useAppPodcastCollapsibleState = () =>
   useAppStore((state) => ({
     collapsibleState: state.podcasts.collapsibleState,

--- a/src/types/serverConfig.ts
+++ b/src/types/serverConfig.ts
@@ -66,6 +66,25 @@ interface IAppSettings {
   setCurrentPage: (page: SettingsOptions) => void
 }
 
+interface IAppArtworkScreens {
+  album: boolean
+  setAlbum: (value: boolean) => void
+  fullscreen: boolean
+  setFullscreen: (value: boolean) => void
+  playerBar: boolean
+  setPlayerBar: (value: boolean) => void
+}
+
+interface IAppArtwork {
+  enabled: boolean
+  setEnabled: (value: boolean) => void
+  customUrlEnabled: boolean
+  setCustomUrlEnabled: (value: boolean) => void
+  baseUrl: string
+  setBaseUrl: (value: string) => void
+  screens: IAppArtworkScreens
+}
+
 interface IPodcasts {
   active: boolean
   setActive: (value: boolean) => void
@@ -104,6 +123,7 @@ export interface IAppContext {
   data: IAppData
   accounts: IAccounts
   podcasts: IPodcasts
+  artwork: IAppArtwork
   pages: IAppPages
   desktop: IDesktop
   command: IAppCommand

--- a/src/types/serverConfig.ts
+++ b/src/types/serverConfig.ts
@@ -73,6 +73,8 @@ interface IAppArtworkScreens {
   setFullscreen: (value: boolean) => void
   playerBar: boolean
   setPlayerBar: (value: boolean) => void
+  drawer: boolean
+  setDrawer: (value: boolean) => void
 }
 
 interface IAppArtwork {

--- a/src/utils/queryKeys.ts
+++ b/src/utils/queryKeys.ts
@@ -7,6 +7,7 @@ const album = {
   all: 'get-all-albums',
   single: 'get-album',
   info: 'get-album-info',
+  animatedArtwork: 'get-animated-album-artwork',
   moreAlbums: 'get-artist-albums',
   genreAlbums: 'get-genre-random-albums',
   recentlyAdded: 'get-recently-added-albums',


### PR DESCRIPTION
This PR adds support for animated album covers using HLS video streams. The feature is completely opt-in and allows users to self-host the backend.

- Add animated artwork integration for album header, fullscreen, and bottom player
- Fetch animated covers from external artwork API using artist/album lookup
- Support native HLS playback with automatic hls.js fallback (not all browsers support it natively)
- Add global and per-screen toggles in settings
- Add custom artwork API base URL (default: https://artwork.m8tec.top)
- Query artwork api with normalized keys and caching to avoid duplicate requests
- Keep static covers as fallback

## Preview

https://github.com/user-attachments/assets/fc64890d-81d6-49ce-b85a-35c52108b36e

https://github.com/user-attachments/assets/c9c11183-6c00-4fcd-acda-04c319eb09e9


### Disclaimer
The default api address used for this feature is an instance of [m8tec/apple-music-animated-artworks](https://github.com/m8tec/apple-music-animated-artworks), hosted and created by me. In case people want to self host, they can just overwrite the address in the settings. The feature is deactivated by default.