### PR TITLE
feat(genres): add genres section with detail pages and playback actions

### DIFF
--- a/src/app/components/fallbacks/genre-fallbacks.tsx
+++ b/src/app/components/fallbacks/genre-fallbacks.tsx
@@ -1,10 +1,38 @@
-import { AlbumFallback } from '@/app/components/fallbacks/album-fallbacks'
+import { ImageHeaderEffect } from '@/app/components/album/header-effect'
+import { AlbumHeaderFallback } from '@/app/components/fallbacks/album-fallbacks'
 import { SongListFallback } from '@/app/components/fallbacks/song-fallbacks'
+import ListWrapper from '@/app/components/list-wrapper'
+import { MainGrid } from '@/app/components/main-grid'
+import { Skeleton } from '@/app/components/ui/skeleton'
 
 export function GenresFallback() {
   return <SongListFallback />
 }
 
 export function GenreFallback() {
-  return <AlbumFallback />
+  return (
+    <div className="w-full">
+      <div className="relative">
+        <AlbumHeaderFallback />
+        <ImageHeaderEffect className="bg-muted-foreground" />
+      </div>
+      <ListWrapper>
+        <div className="flex items-center gap-2">
+          <Skeleton className="rounded-full h-9 w-36" />
+          <Skeleton className="rounded-full h-9 w-36" />
+        </div>
+      </ListWrapper>
+      <ListWrapper className="px-0 pt-0">
+        <MainGrid>
+          {Array.from({ length: 24 }).map((_, index) => (
+            <div key={'genre-card-fallback-' + index}>
+              <Skeleton className="aspect-square" />
+              <Skeleton className="h-[13px] w-11/12 mt-2" />
+              <Skeleton className="h-3 w-1/2 mt-[7px]" />
+            </div>
+          ))}
+        </MainGrid>
+      </ListWrapper>
+    </div>
+  )
 }

--- a/src/app/components/fallbacks/genre-fallbacks.tsx
+++ b/src/app/components/fallbacks/genre-fallbacks.tsx
@@ -1,0 +1,10 @@
+import { AlbumFallback } from '@/app/components/fallbacks/album-fallbacks'
+import { SongListFallback } from '@/app/components/fallbacks/song-fallbacks'
+
+export function GenresFallback() {
+  return <SongListFallback />
+}
+
+export function GenreFallback() {
+  return <AlbumFallback />
+}

--- a/src/app/components/genres/genre-buttons.tsx
+++ b/src/app/components/genres/genre-buttons.tsx
@@ -29,7 +29,7 @@ export function GenreButtons({ genre }: GenreButtonsProps) {
   }
 
   return (
-    <div className="w-full mb-6 flex items-center gap-2">
+    <div className="w-full flex items-center gap-2">
       <Button
         variant="secondary"
         className="rounded-full gap-2 px-5"

--- a/src/app/components/genres/genre-buttons.tsx
+++ b/src/app/components/genres/genre-buttons.tsx
@@ -1,0 +1,52 @@
+import { Disc3, Shuffle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/app/components/ui/button'
+import { subsonic } from '@/service/subsonic'
+import { usePlayerActions } from '@/store/player.store'
+
+interface GenreButtonsProps {
+  genre: string
+}
+
+export function GenreButtons({ genre }: GenreButtonsProps) {
+  const { t } = useTranslation()
+  const { setSongList } = usePlayerActions()
+
+  async function handleShuffleTracks() {
+    const songs = await subsonic.genres.getSongsByGenre({ genre })
+
+    if (songs && songs.length > 0) {
+      setSongList(songs, 0, true)
+    }
+  }
+
+  async function handleShuffleAlbums() {
+    const songs = await subsonic.songs.getRandomSongs({ genre, size: 500 })
+
+    if (songs && songs.length > 0) {
+      setSongList(songs, 0, false)
+    }
+  }
+
+  return (
+    <div className="w-full mb-6 flex items-center gap-2">
+      <Button
+        variant="secondary"
+        className="rounded-full gap-2 px-5"
+        onClick={handleShuffleTracks}
+      >
+        <Shuffle className="w-4 h-4" />
+        {t('genres.buttons.shuffleTracks')}
+      </Button>
+
+      <Button
+        variant="secondary"
+        className="rounded-full gap-2 px-5"
+        onClick={handleShuffleAlbums}
+      >
+        <Disc3 className="w-4 h-4" />
+        {t('genres.buttons.shuffleAlbums')}
+      </Button>
+    </div>
+  )
+}

--- a/src/app/components/ui/data-table-row.tsx
+++ b/src/app/components/ui/data-table-row.tsx
@@ -12,7 +12,8 @@ interface RowProps<TData> extends ComponentPropsWithoutRef<'div'> {
   isPrevRowSelected: (rowIndex: number) => boolean
   isNextRowSelected: (rowIndex: number) => boolean
   variant?: 'classic' | 'modern'
-  dataType?: 'song' | 'artist' | 'playlist' | 'radio'
+  dataType?: 'song' | 'artist' | 'playlist' | 'radio' | 'genre'
+  clickable?: boolean
 }
 
 const MemoContextMenuProvider = memo(ContextMenuProvider)
@@ -24,6 +25,7 @@ export function TableRow<TData>({
   contextMenuOptions,
   variant,
   dataType,
+  clickable,
   isPrevRowSelected,
   isNextRowSelected,
   ...props
@@ -59,6 +61,7 @@ export function TableRow<TData>({
             'rounded-b-md',
           isModern && !row.getIsSelected() && 'rounded-md',
           'hover:bg-foreground/20 data-[state=selected]:bg-foreground/30',
+          clickable && 'cursor-pointer',
           isClassic && 'border-b',
           isRowSongActive && isModern && 'row-active bg-foreground/20',
         )}

--- a/src/app/components/ui/data-table.tsx
+++ b/src/app/components/ui/data-table.tsx
@@ -70,7 +70,8 @@ interface DataTableProps<TData, TValue> {
   showHeader?: boolean
   showDiscNumber?: boolean
   variant?: 'classic' | 'modern'
-  dataType?: 'song' | 'artist' | 'playlist' | 'radio'
+  dataType?: 'song' | 'artist' | 'playlist' | 'radio' | 'genre'
+  onRowClick?: (row: Row<TData>) => void
 }
 
 let isTap = false
@@ -91,6 +92,7 @@ export function DataTable<TData, TValue>({
   showDiscNumber = false,
   variant = 'classic',
   dataType = 'song',
+  onRowClick,
 }: DataTableProps<TData, TValue>) {
   const { t } = useTranslation()
   const newColumns = columns.filter((column) => {
@@ -293,13 +295,17 @@ export function DataTable<TData, TValue>({
   const handleClicks = useCallback(
     (e: MouseEvent<HTMLDivElement>, row: Row<TData>) => {
       if (e.nativeEvent.button === MouseButton.Left) {
-        handleLeftClick(e, row)
+        if (onRowClick) {
+          onRowClick(row)
+        } else {
+          handleLeftClick(e, row)
+        }
       }
       if (e.nativeEvent.button === MouseButton.Right) {
         handleRightClick(row)
       }
     },
-    [handleLeftClick, handleRightClick],
+    [handleLeftClick, handleRightClick, onRowClick],
   )
 
   const handleRowDbClick = useCallback(
@@ -452,6 +458,7 @@ export function DataTable<TData, TValue>({
                       isNextRowSelected={isNextRowSelected}
                       variant={variant}
                       dataType={dataType}
+                      clickable={!!onRowClick}
                       onClick={(e) => handleClicks(e, row)}
                       onDoubleClick={(e) => handleRowDbClick(e, row)}
                       onTouchStart={handleTouchStart}

--- a/src/app/layout/sidebar.tsx
+++ b/src/app/layout/sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Music2Icon,
   PodcastIcon,
   RadioIcon,
+  TagsIcon,
 } from 'lucide-react'
 import { ElementType, memo } from 'react'
 import { ROUTES } from '@/routes/routesList'
@@ -19,6 +20,7 @@ const Home = memo(HomeIcon)
 const Library = memo(LibraryIcon)
 const Podcast = memo(PodcastIcon)
 const Heart = memo(HeartIcon)
+const Tags = memo(TagsIcon)
 
 export interface ISidebarItem {
   id: string
@@ -32,6 +34,7 @@ export enum SidebarItems {
   Artists = 'artists',
   Songs = 'songs',
   Albums = 'albums',
+  Genres = 'genres',
   Favorites = 'favorites',
   Playlists = 'playlists',
   Podcasts = 'podcasts',
@@ -67,6 +70,12 @@ export const libraryItems = [
     title: 'sidebar.albums',
     route: ROUTES.LIBRARY.ALBUMS,
     icon: Library,
+  },
+  {
+    id: SidebarItems.Genres,
+    title: 'sidebar.genres',
+    route: ROUTES.LIBRARY.GENRES,
+    icon: Tags,
   },
   {
     id: SidebarItems.Favorites,

--- a/src/app/pages/genres/genre.tsx
+++ b/src/app/pages/genres/genre.tsx
@@ -1,0 +1,80 @@
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
+import ImageHeader from '@/app/components/album/image-header'
+import { AlbumGridCard } from '@/app/components/albums/album-grid-card'
+import { GenreFallback } from '@/app/components/fallbacks/genre-fallbacks'
+import { GenreButtons } from '@/app/components/genres/genre-buttons'
+import { GridViewWrapper } from '@/app/components/grid-view-wrapper'
+import { BadgesData } from '@/app/components/header-info'
+import ListWrapper from '@/app/components/list-wrapper'
+import ErrorPage from '@/app/pages/error-page'
+import { subsonic } from '@/service/subsonic'
+import { saveGridClickedItem } from '@/utils/gridTools'
+import { queryKeys } from '@/utils/queryKeys'
+
+export default function Genre() {
+  const { genreName } = useParams() as { genreName: string }
+  const { t } = useTranslation()
+
+  const genre = decodeURIComponent(genreName)
+
+  const {
+    data,
+    isLoading,
+    isFetched,
+  } = useQuery({
+    queryKey: [queryKeys.genre.albums, genre],
+    queryFn: () =>
+      subsonic.albums.getAlbumList({ type: 'byGenre', genre, size: 500 }),
+    enabled: !!genre,
+    gcTime: 0,
+  })
+
+  if (isLoading) return <GenreFallback />
+  if (isFetched && !data?.list) {
+    return <ErrorPage status={404} statusText="Not Found" />
+  }
+  if (!data?.list) return <GenreFallback />
+
+  const albums = data.list
+
+  saveGridClickedItem({
+    name: 'genre',
+    offsetTop: 0,
+    routeKey: location.pathname + location.search,
+  })
+
+  const coverArtId = albums[Math.floor(Math.random() * albums.length)]?.coverArt
+
+  const badges: BadgesData = [
+    {
+      content: t('genres.albumCount', { count: albums.length }),
+      type: 'text',
+    },
+  ]
+
+  return (
+    <div className="w-full">
+      <ImageHeader
+        type={t('genre.headline')}
+        title={genre}
+        coverArtId={coverArtId}
+        coverArtType="album"
+        coverArtSize="700"
+        coverArtAlt={genre}
+        badges={badges}
+      />
+
+      <ListWrapper>
+        <GenreButtons genre={genre} />
+      </ListWrapper>
+
+      <ListWrapper className="px-0 pt-0">
+        <GridViewWrapper list={albums} type="genre">
+          {(album) => <AlbumGridCard album={album} />}
+        </GridViewWrapper>
+      </ListWrapper>
+    </div>
+  )
+}

--- a/src/app/pages/genres/list.tsx
+++ b/src/app/pages/genres/list.tsx
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query'
+import { memo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import { ShadowHeader } from '@/app/components/album/shadow-header'
+import { SongListFallback } from '@/app/components/fallbacks/song-fallbacks'
+import { HeaderTitle } from '@/app/components/header-title'
+import ListWrapper from '@/app/components/list-wrapper'
+import { DataTable } from '@/app/components/ui/data-table'
+import { genresColumns } from '@/app/tables/genres-columns'
+import { ROUTES } from '@/routes/routesList'
+import { subsonic } from '@/service/subsonic'
+import { queryKeys } from '@/utils/queryKeys'
+
+const MemoShadowHeader = memo(ShadowHeader)
+const MemoHeaderTitle = memo(HeaderTitle)
+const MemoDataTable = memo(DataTable) as typeof DataTable
+
+export default function GenresList() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const columns = genresColumns()
+
+  const { data: genres, isLoading } = useQuery({
+    queryKey: [queryKeys.genre.all],
+    queryFn: subsonic.genres.get,
+  })
+
+  if (isLoading) return <SongListFallback />
+  if (!genres) return null
+
+  const filteredGenres = genres
+    .filter((genre) => genre.albumCount >= 2)
+    .sort((a, b) => b.songCount - a.songCount)
+
+  return (
+    <div className="w-full h-full">
+      <MemoShadowHeader>
+        <MemoHeaderTitle
+          title={t('sidebar.genres')}
+          count={filteredGenres.length}
+        />
+      </MemoShadowHeader>
+
+      <ListWrapper>
+        <MemoDataTable
+          columns={columns}
+          data={filteredGenres}
+          showPagination={false}
+          showSearch={true}
+          searchColumn="value"
+          allowRowSelection={false}
+          dataType="genre"
+          onRowClick={(row) => navigate(ROUTES.GENRE.PAGE(row.original.value))}
+        />
+      </ListWrapper>
+    </div>
+  )
+}

--- a/src/app/tables/genres-columns.tsx
+++ b/src/app/tables/genres-columns.tsx
@@ -30,6 +30,7 @@ export function genresColumns(): ColumnDefType<Genre>[] {
         <Link
           to={ROUTES.GENRE.PAGE(row.original.value)}
           className="hover:underline font-medium"
+          onClick={(e) => e.stopPropagation()}
         >
           {row.original.value}
         </Link>

--- a/src/app/tables/genres-columns.tsx
+++ b/src/app/tables/genres-columns.tsx
@@ -1,0 +1,69 @@
+import { memo } from 'react'
+import { Link } from 'react-router-dom'
+import { DataTableColumnHeader } from '@/app/components/ui/data-table-column-header'
+import i18n from '@/i18n'
+import { ROUTES } from '@/routes/routesList'
+import { ColumnDefType } from '@/types/react-table/columnDef'
+import { Genre } from '@/types/responses/genre'
+
+const MemoDataTableColumnHeader = memo(
+  DataTableColumnHeader,
+) as typeof DataTableColumnHeader
+
+export function genresColumns(): ColumnDefType<Genre>[] {
+  return [
+    {
+      id: 'value',
+      accessorKey: 'value',
+      enableSorting: true,
+      sortingFn: 'customSortFn',
+      style: {
+        flex: 1,
+        minWidth: 100,
+      },
+      header: ({ column, table }) => (
+        <MemoDataTableColumnHeader column={column} table={table}>
+          {i18n.t('table.columns.name')}
+        </MemoDataTableColumnHeader>
+      ),
+      cell: ({ row }) => (
+        <Link
+          to={ROUTES.GENRE.PAGE(row.original.value)}
+          className="hover:underline font-medium"
+        >
+          {row.original.value}
+        </Link>
+      ),
+    },
+    {
+      id: 'albumCount',
+      accessorKey: 'albumCount',
+      enableSorting: true,
+      sortingFn: 'basic',
+      style: {
+        width: '20%',
+        maxWidth: '20%',
+      },
+      header: ({ column, table }) => (
+        <MemoDataTableColumnHeader column={column} table={table}>
+          {i18n.t('table.columns.albumCount')}
+        </MemoDataTableColumnHeader>
+      ),
+    },
+    {
+      id: 'songCount',
+      accessorKey: 'songCount',
+      enableSorting: true,
+      sortingFn: 'basic',
+      style: {
+        width: '20%',
+        maxWidth: '20%',
+      },
+      header: ({ column, table }) => (
+        <MemoDataTableColumnHeader column={column} table={table}>
+          {i18n.t('table.columns.songCount')}
+        </MemoDataTableColumnHeader>
+      ),
+    },
+  ]
+}

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -17,7 +17,8 @@
     "podcasts": "Podcasty",
     "miniSearch": "Hledat",
     "radios": "Rádiové stanice",
-    "artists": "Umělci"
+    "artists": "Umělci",
+    "genres": "Žánry"
   },
   "menu": {
     "language": "Jazyk",
@@ -478,6 +479,19 @@
     },
     "emptyPage": {
       "message": "Nebyly přidány žádné podcasty"
+    }
+  },
+  "genre": {
+    "headline": "Žánr"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} album",
+    "albumCount_few": "{{count}} alba",
+    "albumCount_many": "{{count}} alb",
+    "albumCount_other": "{{count}} alba",
+    "buttons": {
+      "shuffleTracks": "Náhodné skladby",
+      "shuffleAlbums": "Náhodná alba"
     }
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -11,7 +11,8 @@
     "favorites": "Favoriten",
     "playlists": "Wiedergabelisten",
     "emptyPlaylist": "Noch keine Wiedergabelisten erstellt",
-    "podcasts": "Podcasts"
+    "podcasts": "Podcasts",
+    "genres": "Genres"
   },
   "theme": {
     "nuclear-dark": "Nuclear Dark",
@@ -732,6 +733,17 @@
     "emptyPage": {
       "description": "Es sieht so aus, als noch keine Podcasts hinzugefügt wurden. Füge oberhalb einen hinzu!",
       "message": "Kein Podcast hinzugefügt"
+    }
+  },
+  "genre": {
+    "headline": "Genre"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} Album",
+    "albumCount_other": "{{count}} Alben",
+    "buttons": {
+      "shuffleTracks": "Titel zufällig",
+      "shuffleAlbums": "Alben zufällig"
     }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -17,6 +17,7 @@
     "playlists": "Playlists",
     "radios": "Radios",
     "podcasts": "Podcasts",
+    "genres": "Genres",
     "emptyPlaylist": "No playlists created yet"
   },
   "menu": {
@@ -185,6 +186,17 @@
     },
     "table": {
       "discNumber": "Disc {{number}}"
+    }
+  },
+  "genre": {
+    "headline": "Genre"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} album",
+    "albumCount_other": "{{count}} albums",
+    "buttons": {
+      "shuffleTracks": "Shuffle Tracks",
+      "shuffleAlbums": "Shuffle Albums"
     }
   },
   "favorites": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -17,7 +17,8 @@
     "playlists": "Listas de reproducción",
     "radios": "Radios",
     "emptyPlaylist": "Aún no se han creado listas de reproducción",
-    "podcasts": "Podcasts"
+    "podcasts": "Podcasts",
+    "genres": "Géneros"
   },
   "menu": {
     "language": "Idioma",
@@ -718,5 +719,16 @@
       }
     },
     "label": "Configuración"
+  },
+  "genre": {
+    "headline": "Género"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} álbum",
+    "albumCount_other": "{{count}} álbumes",
+    "buttons": {
+      "shuffleTracks": "Canciones aleatorias",
+      "shuffleAlbums": "Álbumes aleatorios"
+    }
   }
 }

--- a/src/i18n/locales/eu.json
+++ b/src/i18n/locales/eu.json
@@ -17,7 +17,8 @@
     "playlists": "Zerrendak",
     "radios": "Irratiak",
     "podcasts": "Podcast-ak",
-    "emptyPlaylist": "Ez da oraindik zerrendarik sortu"
+    "emptyPlaylist": "Ez da oraindik zerrendarik sortu",
+    "genres": "Generoak"
   },
   "menu": {
     "language": "Hizkuntza",
@@ -58,5 +59,16 @@
     "songCount_other": "{{count}} abesti",
     "duration": "{{duration}} inguru",
     "refresh": "Zerrenda berritu"
+  },
+  "genre": {
+    "headline": "Generoa"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} album",
+    "albumCount_other": "{{count}} album",
+    "buttons": {
+      "shuffleTracks": "Abestiak ausaz",
+      "shuffleAlbums": "Albumak ausaz"
+    }
   }
 }

--- a/src/i18n/locales/fr-CA.json
+++ b/src/i18n/locales/fr-CA.json
@@ -444,7 +444,8 @@
     "search": "Recherche…",
     "miniSearch": "Recherche",
     "library": "Bibliothèque",
-    "artists": "Artistes"
+    "artists": "Artistes",
+    "genres": "Genres"
   },
   "menu": {
     "language": "Langue",
@@ -740,5 +741,16 @@
     "clear": "Vider la file d'attente",
     "close": "Fermer la file d'attente",
     "open": "Ouvrir la file d'attente"
+  },
+  "genre": {
+    "headline": "Genre"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} album",
+    "albumCount_other": "{{count}} albums",
+    "buttons": {
+      "shuffleTracks": "Pistes aléatoires",
+      "shuffleAlbums": "Albums aléatoires"
+    }
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -136,7 +136,8 @@
     "library": "Bibliothèque",
     "artists": "Artistes",
     "emptyPlaylist": "Aucune liste de lecture créée",
-    "podcasts": "Podcasts"
+    "podcasts": "Podcasts",
+    "genres": "Genres"
   },
   "menu": {
     "serverLogout": "Se déconnecter",
@@ -748,6 +749,17 @@
       "success": "La mise à jour a été installée ! L'application va redémarrer.",
       "started": "La mise à jour a commencé.",
       "error": "L'installation de la mise à jour a échoué. Veuillez la télécharger directement depuis GitHub."
+    }
+  },
+  "genre": {
+    "headline": "Genre"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} album",
+    "albumCount_other": "{{count}} albums",
+    "buttons": {
+      "shuffleTracks": "Pistes aléatoires",
+      "shuffleAlbums": "Albums aléatoires"
     }
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -12,6 +12,7 @@
     "albums": "Album",
     "songs": "Brani",
     "podcasts": "Podcast",
+    "genres": "Generi",
     "emptyPlaylist": "Nessuna playlist creata",
     "miniSearch": "Cerca",
     "library": "Libreria",
@@ -190,6 +191,17 @@
     "beta": "Beta",
     "showDetails": "Mostra dettagli",
     "seeMore": "Per saperne di più"
+  },
+  "genre": {
+    "headline": "Genere"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} album",
+    "albumCount_other": "{{count}} album",
+    "buttons": {
+      "shuffleTracks": "Tracce casuali",
+      "shuffleAlbums": "Album casuali"
+    }
   },
   "favorites": {
     "noSongList": "Non hai ancora aggiunto brani ai preferiti!"

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -35,7 +35,8 @@
     "radios": "라디오",
     "podcasts": "팟캐스트",
     "emptyPlaylist": "생성된 재생목록 없음",
-    "favorites": "즐겨찾기"
+    "favorites": "즐겨찾기",
+    "genres": "장르"
   },
   "playlist": {
     "buttons": {
@@ -720,6 +721,17 @@
     "server": {
       "error": "서버와의 통신에 실패했습니다!",
       "success": "서버가 저장되었습니다!"
+    }
+  },
+  "genre": {
+    "headline": "장르"
+  },
+  "genres": {
+    "albumCount_one": "앨범 {{count}}개",
+    "albumCount_other": "앨범 {{count}}개",
+    "buttons": {
+      "shuffleTracks": "트랙 셔플",
+      "shuffleAlbums": "앨범 셔플"
     }
   }
 }

--- a/src/i18n/locales/ml.json
+++ b/src/i18n/locales/ml.json
@@ -7,6 +7,18 @@
     "miniSearch": "തിരയുക",
     "songs": "ഗാനങ്ങൾ",
     "albums": "ആൽബങ്ങൾ",
-    "playlists": "പ്ലേലിസ്റ്റുകൾ"
+    "playlists": "പ്ലേലിസ്റ്റുകൾ",
+    "genres": "ഴോൺറുകൾ"
+  },
+  "genre": {
+    "headline": "ഴോൺർ"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} ആൽബം",
+    "albumCount_other": "{{count}} ആൽബങ്ങൾ",
+    "buttons": {
+      "shuffleTracks": "ട്രാക്കുകൾ ഷഫിൾ",
+      "shuffleAlbums": "ആൽബങ്ങൾ ഷഫിൾ"
+    }
   }
 }

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -207,7 +207,8 @@
     "artists": "Wykonawcy",
     "playlists": "Playlisty",
     "emptyPlaylist": "Nie utworzono jeszcze playlist",
-    "favorites": "Ulubione"
+    "favorites": "Ulubione",
+    "genres": "Gatunki"
   },
   "playlist": {
     "headline": "Playlista",
@@ -756,5 +757,18 @@
   "warnings": {
     "songError": "Nie można odtworzyć piosenki, sprawdź Serwer!",
     "reload": "Piosenka jest odtwarzana!\nCzy na pewno chcesz odświeżyć stronę?"
+  },
+  "genre": {
+    "headline": "Gatunek"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} album",
+    "albumCount_few": "{{count}} albumy",
+    "albumCount_many": "{{count}} albumów",
+    "albumCount_other": "{{count}} albumów",
+    "buttons": {
+      "shuffleTracks": "Losowe utwory",
+      "shuffleAlbums": "Losowe albumy"
+    }
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -17,7 +17,8 @@
     "playlists": "Playlists",
     "radios": "Rádios",
     "podcasts": "Podcasts",
-    "emptyPlaylist": "Nenhuma playlist criada ainda"
+    "emptyPlaylist": "Nenhuma playlist criada ainda",
+    "genres": "Gêneros"
   },
   "menu": {
     "language": "Linguagem",
@@ -760,6 +761,17 @@
       "MM": "%d meses",
       "y": "1 ano",
       "yy": "%d anos"
+    }
+  },
+  "genre": {
+    "headline": "Gênero"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} álbum",
+    "albumCount_other": "{{count}} álbuns",
+    "buttons": {
+      "shuffleTracks": "Faixas aleatórias",
+      "shuffleAlbums": "Álbuns aleatórios"
     }
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -533,7 +533,8 @@
     "playlists": "Playlists",
     "radios": "Rádios",
     "podcasts": "Podcasts",
-    "emptyPlaylist": "Nenhuma playlist criada ainda"
+    "emptyPlaylist": "Nenhuma playlist criada ainda",
+    "genres": "Géneros"
   },
   "menu": {
     "language": "Linguagem",
@@ -750,6 +751,17 @@
       "MM": "%d meses",
       "y": "1 ano",
       "yy": "%d anos"
+    }
+  },
+  "genre": {
+    "headline": "Género"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} álbum",
+    "albumCount_other": "{{count}} álbuns",
+    "buttons": {
+      "shuffleTracks": "Faixas aleatórias",
+      "shuffleAlbums": "Álbuns aleatórios"
     }
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -23,7 +23,8 @@
     "search": "Поиск…",
     "home": "Главная",
     "emptyPlaylist": "Пока не создано ни одного плейлиста",
-    "podcasts": "Подкасты"
+    "podcasts": "Подкасты",
+    "genres": "Жанры"
   },
   "generic": {
     "loading": "Загрузка…",
@@ -740,6 +741,19 @@
         },
         "group": "Статус в Discord"
       }
+    }
+  },
+  "genre": {
+    "headline": "Жанр"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} альбом",
+    "albumCount_few": "{{count}} альбома",
+    "albumCount_many": "{{count}} альбомов",
+    "albumCount_other": "{{count}} альбомов",
+    "buttons": {
+      "shuffleTracks": "Перемешать треки",
+      "shuffleAlbums": "Перемешать альбомы"
     }
   }
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -10,7 +10,8 @@
     "playlists": "Spellista",
     "songs": "Sånger",
     "emptyPlaylist": "Inga spellistor skapat ännu",
-    "library": "Bibliotek"
+    "library": "Bibliotek",
+    "genres": "Genrer"
   },
   "home": {
     "recentlyAdded": "Nyligen tillagd",
@@ -545,6 +546,17 @@
       "MM": "%d månader",
       "y": "1 år",
       "yy": "%d år"
+    }
+  },
+  "genre": {
+    "headline": "Genre"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} album",
+    "albumCount_other": "{{count}} album",
+    "buttons": {
+      "shuffleTracks": "Blanda spår",
+      "shuffleAlbums": "Blanda album"
     }
   }
 }

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -16,7 +16,8 @@
     "playlists": "Çalma Listeleri",
     "radios": "Radyo İstasyonları",
     "podcasts": "Podcastler",
-    "emptyPlaylist": "Henüz çalma listesi oluşturulmadı"
+    "emptyPlaylist": "Henüz çalma listesi oluşturulmadı",
+    "genres": "Türler"
   },
   "menu": {
     "language": "Dil",
@@ -726,6 +727,17 @@
       "MM": "%d ay",
       "y": "1 yıl",
       "yy": "%d yıl"
+    }
+  },
+  "genre": {
+    "headline": "Tür"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} albüm",
+    "albumCount_other": "{{count}} albüm",
+    "buttons": {
+      "shuffleTracks": "Parçaları karıştır",
+      "shuffleAlbums": "Albümleri karıştır"
     }
   }
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -52,7 +52,8 @@
     "playlists": "Списки відтворення",
     "radios": "Радіо",
     "podcasts": "Подкасти",
-    "emptyPlaylist": "Ще не було створено жодного списку відтворення"
+    "emptyPlaylist": "Ще не було створено жодного списку відтворення",
+    "genres": "Жанри"
   },
   "menu": {
     "server": "Сервер",
@@ -81,5 +82,18 @@
     "nuclear-dark": "Атомні сутінки",
     "achiever": "Achiever",
     "dracula": "Dracula"
+  },
+  "genre": {
+    "headline": "Жанр"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} альбом",
+    "albumCount_few": "{{count}} альбоми",
+    "albumCount_many": "{{count}} альбомів",
+    "albumCount_other": "{{count}} альбомів",
+    "buttons": {
+      "shuffleTracks": "Перемішати треки",
+      "shuffleAlbums": "Перемішати альбоми"
+    }
   }
 }

--- a/src/i18n/locales/zh-Hans.json
+++ b/src/i18n/locales/zh-Hans.json
@@ -17,7 +17,8 @@
     "favorites": "收藏夹",
     "search": "搜索…",
     "miniSearch": "搜索",
-    "podcasts": "播客"
+    "podcasts": "播客",
+    "genres": "流派"
   },
   "menu": {
     "about": "关于",
@@ -720,6 +721,17 @@
         "description": "请尝试添加更多播客。",
         "goToPodcasts": "前往播客"
       }
+    }
+  },
+  "genre": {
+    "headline": "流派"
+  },
+  "genres": {
+    "albumCount_one": "{{count}} 张专辑",
+    "albumCount_other": "{{count}} 张专辑",
+    "buttons": {
+      "shuffleTracks": "随机曲目",
+      "shuffleAlbums": "随机专辑"
     }
   }
 }

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -6,6 +6,10 @@ import {
   AlbumsFallback,
 } from '@/app/components/fallbacks/album-fallbacks'
 import { ArtistsFallback } from '@/app/components/fallbacks/artists.tsx'
+import {
+  GenreFallback,
+  GenresFallback,
+} from '@/app/components/fallbacks/genre-fallbacks'
 import { HomeFallback } from '@/app/components/fallbacks/home-fallbacks'
 import { PlaylistFallback } from '@/app/components/fallbacks/playlist-fallbacks'
 import {
@@ -35,6 +39,9 @@ const Playlist = lazy(() => import('@/app/pages/playlists/playlist'))
 const Radios = lazy(() => import('@/app/pages/radios/radios-list'))
 const SongList = lazy(() => import('@/app/pages/songs/songlist'))
 const Home = lazy(() => import('@/app/pages/home'))
+const GenresList = lazy(() => import('@/app/pages/genres/list'))
+const GenrePage = lazy(() => import('@/app/pages/genres/genre'))
+
 const PodcastsList = lazy(() => import('@/app/pages/podcasts/list'))
 const Podcast = lazy(() => import('@/app/pages/podcasts/podcast'))
 const Episode = lazy(() => import('@/app/pages/podcasts/episode'))
@@ -116,6 +123,26 @@ export const router = createHashRouter([
         element: (
           <Suspense fallback={<SongListFallback />}>
             <Radios />
+          </Suspense>
+        ),
+      },
+      {
+        id: 'genres',
+        path: ROUTES.LIBRARY.GENRES,
+        errorElement: <ErrorPage />,
+        element: (
+          <Suspense fallback={<GenresFallback />}>
+            <GenresList />
+          </Suspense>
+        ),
+      },
+      {
+        id: 'genre',
+        path: ROUTES.GENRE.PATH,
+        errorElement: <ErrorPage />,
+        element: (
+          <Suspense fallback={<GenreFallback />}>
+            <GenrePage />
           </Suspense>
         ),
       },

--- a/src/routes/routesList.ts
+++ b/src/routes/routesList.ts
@@ -11,6 +11,7 @@ const LIBRARY = {
   PODCASTS: '/library/podcasts',
   EPISODES: '/library/episodes',
   RADIOS: '/library/radios',
+  GENRES: '/library/genres',
 }
 
 const ARTIST = {
@@ -66,6 +67,12 @@ const EPISODES = {
   LATEST: `${LIBRARY.EPISODES}/latest`,
 }
 
+const GENRE = {
+  PAGE: (genreName: string) =>
+    `${LIBRARY.GENRES}/${encodeURIComponent(genreName)}`,
+  PATH: `${LIBRARY.GENRES}/:genreName`,
+}
+
 const SERVER_CONFIG = '/server-config'
 
 export const ROUTES = {
@@ -78,5 +85,6 @@ export const ROUTES = {
   PLAYLIST,
   PODCASTS,
   EPISODES,
+  GENRE,
   SERVER_CONFIG,
 }

--- a/src/service/genres.ts
+++ b/src/service/genres.ts
@@ -1,5 +1,6 @@
 import { httpClient } from '@/api/httpClient'
 import { GenresResponse } from '@/types/responses/genre'
+import { SongsByGenreResponse } from '@/types/responses/song'
 
 async function get() {
   const response = await httpClient<GenresResponse>('/getGenres', {
@@ -9,6 +10,30 @@ async function get() {
   return response?.data.genres.genre
 }
 
+interface GetSongsByGenreParams {
+  genre: string
+  count?: number
+  offset?: number
+}
+
+async function getSongsByGenre({
+  genre,
+  count = 500,
+  offset = 0,
+}: GetSongsByGenreParams) {
+  const response = await httpClient<SongsByGenreResponse>('/getSongsByGenre', {
+    method: 'GET',
+    query: {
+      genre,
+      count: count.toString(),
+      offset: offset.toString(),
+    },
+  })
+
+  return response?.data.songsByGenre.song
+}
+
 export const genres = {
   get,
+  getSongsByGenre,
 }

--- a/src/utils/gridTools.ts
+++ b/src/utils/gridTools.ts
@@ -1,4 +1,4 @@
-export type GridViewWrapperType = 'artists' | 'albums'
+export type GridViewWrapperType = 'artists' | 'albums' | 'genre'
 
 type SavedGridItem = Record<string, number>
 


### PR DESCRIPTION
## What
- Added a new Genres section in the sidebar
- Genre list page with sortable columns (name, album count, song count) and search
- Clicking any row navigates to the genre detail page
- Genre detail page shows all albums of that genre in a grid
- "Shuffle Tracks" and "Shuffle Albums" buttons to start playback directly from a genre
- Genre pages always scroll to the top when opened
- Translations in 18 languages

## How
- New Subsonic API service for getGenres and getSongsByGenre
- Genre detail uses GridViewWrapper with dedicated 'genre' type to isolate scroll state from the albums grid
- Saved scroll offset is reset on each genre page render to prevent GridViewWrapper's built-in scroll restoration
- Added onRowClick prop to DataTable and clickable to TableRow to support row-level navigation
- Removed unused genre-card.tsx component

## Notes
- Depending on the tags in each user's library, the genre list can become 
  very long. A possible future improvement could be merging similar genres 
  or allowing the user to filter/hide genres — left open intentionally to 
  respect each user's library structure.

---
I hope this turns out to be a useful feature! I took the liberty of proposing 
this contribution because I think this app is really beautiful, but for my 
taste this was a must-have feature. I built my own version with it and I'm 
really enjoying it — hope you like it too! 🎵