### PR TITLE
Extend favorites and playlist visibility toggles beyond sidebar

### DIFF
--- a/src/app/components/album/buttons.tsx
+++ b/src/app/components/album/buttons.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { Actions } from '@/app/components/actions'
 import { subsonic } from '@/service/subsonic'
-import { useAppPages } from '@/store/app.store'
+import { useAppPages, useAppStore } from '@/store/app.store'
 import {
   useIsAlbumPlaying,
   usePlayerActions,
@@ -26,6 +26,7 @@ export function AlbumButtons({ album, showInfoButton }: AlbumButtonsProps) {
   const isShuffleActive = usePlayerStore(
     (state) => state.playerState.isShuffleActive,
   )
+  const hideFavoritesSection = useAppStore().pages.hideFavoritesSection
   const isAlbumStarred = album.starred !== undefined
 
   const queryClient = useQueryClient()
@@ -102,9 +103,16 @@ export function AlbumButtons({ album, showInfoButton }: AlbumButtonsProps) {
         </Actions.Button>
       )}
 
-      <Actions.Button tooltip={buttonsTooltips.like} onClick={handleLikeButton}>
-        <Actions.LikeIcon isStarred={isAlbumStarred} />
-      </Actions.Button>
+      {!hideFavoritesSection && (
+        <>
+          <Actions.Button
+            tooltip={buttonsTooltips.like}
+            onClick={handleLikeButton}
+          >
+            <Actions.LikeIcon isStarred={isAlbumStarred} />
+          </Actions.Button>
+        </>
+      )}
 
       {showInfoButton && (
         <Actions.Button

--- a/src/app/components/album/options.tsx
+++ b/src/app/components/album/options.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuSeparator,
 } from '@/app/components/ui/dropdown-menu'
 import { useOptions } from '@/app/hooks/use-options'
+import { useAppStore } from '@/store/app.store'
 import { SingleAlbum } from '@/types/responses/album'
 
 interface AlbumOptionsProps {
@@ -13,6 +14,7 @@ interface AlbumOptionsProps {
 }
 
 export function AlbumOptions({ album }: AlbumOptionsProps) {
+  const hidePlaylistsSection = useAppStore().pages.hidePlaylistsSection
   const {
     playNext,
     playLast,
@@ -51,14 +53,18 @@ export function AlbumOptions({ album }: AlbumOptionsProps) {
         <OptionsButtons.PlayNext onClick={handlePlayNext} />
         <OptionsButtons.PlayLast onClick={handlePlayLast} />
       </DropdownMenuGroup>
-      <DropdownMenuSeparator />
-      <OptionsButtons.AddToPlaylistOption variant="dropdown">
-        <AddToPlaylistSubMenu
-          type="dropdown"
-          newPlaylistFn={handleCreateNewPlaylist}
-          addToPlaylistFn={handleAddToPlaylist}
-        />
-      </OptionsButtons.AddToPlaylistOption>
+      {!hidePlaylistsSection && (
+        <>
+          <DropdownMenuSeparator />
+          <OptionsButtons.AddToPlaylistOption variant="dropdown">
+            <AddToPlaylistSubMenu
+              type="dropdown"
+              newPlaylistFn={handleCreateNewPlaylist}
+              addToPlaylistFn={handleAddToPlaylist}
+            />
+          </OptionsButtons.AddToPlaylistOption>
+        </>
+      )}
       <DownloadOptionHandler>
         <OptionsButtons.Download onClick={handleDownload} />
       </DownloadOptionHandler>

--- a/src/app/components/albums/filters/main.tsx
+++ b/src/app/components/albums/filters/main.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@/app/components/ui/dropdown-menu'
+import { useAppStore } from '@/store/app.store'
 import { AlbumListType } from '@/types/responses/album'
 import {
   AlbumsFilters,
@@ -18,12 +19,17 @@ import {
 import { scrollPageToTop } from '@/utils/scrollPageToTop'
 import { SearchParamsHandler } from '@/utils/searchParamsHandler'
 
-const hiddenFilters = [AlbumsFilters.ByDiscography, AlbumsFilters.Search]
-
 export function AlbumsMainFilter() {
+  const hideFavoritesSection = useAppStore().pages.hideFavoritesSection
   const { t } = useTranslation()
   const [searchParams, setSearchParams] = useSearchParams()
   const { getSearchParam } = new SearchParamsHandler(searchParams)
+
+  const hiddenFilters = [
+    AlbumsFilters.ByDiscography,
+    AlbumsFilters.Search,
+    ...(hideFavoritesSection ? [AlbumsFilters.Starred] : []),
+  ]
 
   const currentFilter = getSearchParam<AlbumListType>(
     AlbumsSearchParams.MainFilter,

--- a/src/app/components/artist/buttons.tsx
+++ b/src/app/components/artist/buttons.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Actions } from '@/app/components/actions'
 import { useSongList } from '@/app/hooks/use-song-list'
 import { subsonic } from '@/service/subsonic'
-import { useAppPages } from '@/store/app.store'
+import { useAppPages, useAppStore } from '@/store/app.store'
 import {
   useIsArtistPlaying,
   usePlayerActions,
@@ -32,6 +32,7 @@ export function ArtistButtons({
   const isShuffleActive = usePlayerStore(
     (state) => state.playerState.isShuffleActive,
   )
+  const hideFavoritesSection = useAppStore().pages.hideFavoritesSection
   const isArtistStarred = artist.starred !== undefined
 
   const queryClient = useQueryClient()
@@ -115,10 +116,16 @@ export function ArtistButtons({
         <Actions.ShuffleIcon />
       </Actions.Button>
 
-      <Actions.Button tooltip={buttonsTooltips.like} onClick={handleLikeButton}>
-        <Actions.LikeIcon isStarred={isArtistStarred} />
-      </Actions.Button>
-
+      {!hideFavoritesSection && (
+        <>
+          <Actions.Button
+            tooltip={buttonsTooltips.like}
+            onClick={handleLikeButton}
+          >
+            <Actions.LikeIcon isStarred={isArtistStarred} />
+          </Actions.Button>
+        </>
+      )}
       {showInfoButton && (
         <Actions.Button
           tooltip={buttonsTooltips.info}

--- a/src/app/components/fullscreen/player.tsx
+++ b/src/app/components/fullscreen/player.tsx
@@ -1,3 +1,4 @@
+import { useAppStore } from '@/store/app.store'
 import { CloseFullscreenButton } from './buttons'
 import { FullscreenControls } from './controls'
 import { LikeButton } from './like-button'
@@ -6,6 +7,7 @@ import { FullscreenSettings } from './settings'
 import { VolumeContainer } from './volume-container'
 
 export function FullscreenPlayer() {
+  const hideFavoritesSection = useAppStore().pages.hideFavoritesSection
   return (
     <div className="w-full">
       <FullscreenProgress />
@@ -21,7 +23,7 @@ export function FullscreenPlayer() {
         </div>
 
         <div className="w-[200px] flex items-center gap-4 justify-end">
-          <LikeButton />
+          {!hideFavoritesSection && <LikeButton />}
           <VolumeContainer />
         </div>
       </div>

--- a/src/app/components/player/player.tsx
+++ b/src/app/components/player/player.tsx
@@ -5,6 +5,7 @@ import { MiniPlayerButton } from '@/app/components/mini-player/button'
 import { RadioInfo } from '@/app/components/player/radio-info'
 import { TrackInfo } from '@/app/components/player/track-info'
 import { podcasts } from '@/service/podcasts'
+import { useAppStore } from '@/store/app.store'
 import {
   getVolume,
   usePlayerActions,
@@ -47,6 +48,7 @@ const MemoLyricsButton = memo(PlayerLyricsButton)
 const MemoMiniPlayerButton = memo(MiniPlayerButton)
 
 export function Player() {
+  const hideFavoritesSection = useAppStore().pages.hideFavoritesSection
   const audioRef = useRef<HTMLAudioElement>(null)
   const radioRef = useRef<HTMLAudioElement>(null)
   const podcastRef = useRef<HTMLAudioElement>(null)
@@ -212,9 +214,13 @@ export function Player() {
         {/* Remain Controls and Volume */}
         <div className="flex items-center w-full justify-end">
           <div className="flex items-center gap-1">
-            {isSong && (
+            {isSong && !hideFavoritesSection && (
               <>
                 <MemoPlayerLikeButton disabled={!song} />
+              </>
+            )}
+            {isSong && (
+              <>
                 <MemoLyricsButton disabled={!song} />
                 <MemoPlayerQueueButton disabled={!song} />
               </>

--- a/src/app/components/settings/pages/content/features.tsx
+++ b/src/app/components/settings/pages/content/features.tsx
@@ -1,0 +1,61 @@
+import { useTranslation } from 'react-i18next'
+import {
+  Content,
+  ContentItem,
+  ContentItemForm,
+  ContentItemTitle,
+  ContentSeparator,
+  Header,
+  HeaderDescription,
+  HeaderTitle,
+  Root,
+} from '@/app/components/settings/section'
+import { Switch } from '@/app/components/ui/switch'
+import { useAppPages } from '@/store/app.store'
+
+const hideFavoritesSectionConfig = window.HIDE_FAVORITES_SECTION ?? false
+const hidePlaylistsSectionConfig = window.HIDE_PLAYLISTS_SECTION ?? false
+
+export function FeatureContent() {
+  const { t } = useTranslation()
+  const {
+    hideFavoritesSection,
+    setHideFavoritesSection,
+    hidePlaylistsSection,
+    setHidePlaylistsSection,
+  } = useAppPages()
+
+  return (
+    <Root>
+      <Header>
+        <HeaderTitle>{t('settings.content.features.group')}</HeaderTitle>
+        <HeaderDescription>
+          {t('settings.content.features.description')}
+        </HeaderDescription>
+      </Header>
+      <Content>
+        <ContentItem>
+          <ContentItemTitle>{t('sidebar.favorites')}</ContentItemTitle>
+          <ContentItemForm>
+            <Switch
+              checked={!hideFavoritesSection}
+              onCheckedChange={(val) => setHideFavoritesSection(!val)}
+              disabled={hideFavoritesSectionConfig}
+            />
+          </ContentItemForm>
+        </ContentItem>
+        <ContentItem>
+          <ContentItemTitle>{t('sidebar.playlists')}</ContentItemTitle>
+          <ContentItemForm>
+            <Switch
+              checked={!hidePlaylistsSection}
+              onCheckedChange={(val) => setHidePlaylistsSection(!val)}
+              disabled={hidePlaylistsSectionConfig}
+            />
+          </ContentItemForm>
+        </ContentItem>
+      </Content>
+      <ContentSeparator />
+    </Root>
+  )
+}

--- a/src/app/components/settings/pages/content/index.tsx
+++ b/src/app/components/settings/pages/content/index.tsx
@@ -1,3 +1,4 @@
+import { FeatureContent } from './features'
 import { ImagesContent } from './images'
 import { PodcastContent } from './podcast'
 import { SidebarContent } from './sidebar'
@@ -6,6 +7,7 @@ export function Content() {
   return (
     <div className="space-y-4">
       <SidebarContent />
+      <FeatureContent />
       <PodcastContent />
       <ImagesContent />
     </div>

--- a/src/app/components/settings/pages/content/sidebar.tsx
+++ b/src/app/components/settings/pages/content/sidebar.tsx
@@ -17,8 +17,6 @@ const hideArtistsSectionConfig = window.HIDE_ARTISTS_SECTION ?? false
 const hideSongsSectionConfig = window.HIDE_SONGS_SECTION ?? false
 const hideAlbumsSectionConfig = window.HIDE_ALBUMS_SECTION ?? false
 const hideGenresSectionConfig = window.HIDE_GENRES_SECTION ?? false
-const hideFavoritesSectionConfig = window.HIDE_FAVORITES_SECTION ?? false
-const hidePlaylistsSectionConfig = window.HIDE_PLAYLISTS_SECTION ?? false
 const hideRadiosSectionConfig = window.HIDE_RADIOS_SECTION ?? false
 
 export function SidebarContent() {
@@ -32,10 +30,6 @@ export function SidebarContent() {
     setHideAlbumsSection,
     hideGenresSection,
     setHideGenresSection,
-    hideFavoritesSection,
-    setHideFavoritesSection,
-    hidePlaylistsSection,
-    setHidePlaylistsSection,
     hideRadiosSection,
     setHideRadiosSection,
   } = useAppPages()
@@ -86,26 +80,6 @@ export function SidebarContent() {
               checked={!hideGenresSection}
               onCheckedChange={(val) => setHideGenresSection(!val)}
               disabled={hideGenresSectionConfig}
-            />
-          </ContentItemForm>
-        </ContentItem>
-        <ContentItem>
-          <ContentItemTitle>{t('sidebar.favorites')}</ContentItemTitle>
-          <ContentItemForm>
-            <Switch
-              checked={!hideFavoritesSection}
-              onCheckedChange={(val) => setHideFavoritesSection(!val)}
-              disabled={hideFavoritesSectionConfig}
-            />
-          </ContentItemForm>
-        </ContentItem>
-        <ContentItem>
-          <ContentItemTitle>{t('sidebar.playlists')}</ContentItemTitle>
-          <ContentItemForm>
-            <Switch
-              checked={!hidePlaylistsSection}
-              onCheckedChange={(val) => setHidePlaylistsSection(!val)}
-              disabled={hidePlaylistsSectionConfig}
             />
           </ContentItemForm>
         </ContentItem>

--- a/src/app/components/sidebar/nav-playlists.tsx
+++ b/src/app/components/sidebar/nav-playlists.tsx
@@ -10,16 +10,20 @@ import {
 } from '@/app/components/ui/main-sidebar'
 import { ScrollArea } from '@/app/components/ui/scroll-area'
 import { subsonic } from '@/service/subsonic'
+import { useAppStore } from '@/store/app.store'
 import { queryKeys } from '@/utils/queryKeys'
 import { SidebarPlaylistItem } from './playlist-item'
 
 export function NavPlaylists() {
   const { t } = useTranslation()
+  const hidePlaylistsSection = useAppStore().pages.hidePlaylistsSection
 
   const { data: playlists } = useQuery({
     queryKey: [queryKeys.playlist.all],
     queryFn: subsonic.playlists.getAll,
   })
+
+  if (hidePlaylistsSection) return null
 
   const hasPlaylists = playlists !== undefined && playlists.length > 0
 

--- a/src/app/components/song/menu-options.tsx
+++ b/src/app/components/song/menu-options.tsx
@@ -2,6 +2,7 @@ import { OptionsButtons } from '@/app/components/options/buttons'
 import { DownloadOptionHandler } from '@/app/components/options/download-handler'
 import { ContextMenuSeparator } from '@/app/components/ui/context-menu'
 import { useOptions } from '@/app/hooks/use-options'
+import { useAppStore } from '@/store/app.store'
 import { ISong } from '@/types/responses/song'
 import { AddToPlaylistSubMenu } from './add-to-playlist'
 
@@ -26,6 +27,7 @@ export function SongMenuOptions({
     openSongInfo,
     isOnPlaylistPage,
   } = useOptions()
+  const hidePlaylistsSection = useAppStore().pages.hidePlaylistsSection
   const songIndexes = [index.toString()]
 
   return (
@@ -44,14 +46,18 @@ export function SongMenuOptions({
           playLast([song])
         }}
       />
-      <ContextMenuSeparator />
-      <OptionsButtons.AddToPlaylistOption variant={variant}>
-        <AddToPlaylistSubMenu
-          type={variant}
-          newPlaylistFn={() => createNewPlaylist(song.title, song.id)}
-          addToPlaylistFn={(id) => addToPlaylist(id, song.id)}
-        />
-      </OptionsButtons.AddToPlaylistOption>
+      {!hidePlaylistsSection && (
+        <>
+          <ContextMenuSeparator />
+          <OptionsButtons.AddToPlaylistOption variant={variant}>
+            <AddToPlaylistSubMenu
+              type={variant}
+              newPlaylistFn={() => createNewPlaylist(song.title, song.id)}
+              addToPlaylistFn={(id) => addToPlaylist(id, song.id)}
+            />
+          </OptionsButtons.AddToPlaylistOption>
+        </>
+      )}
       {isOnPlaylistPage && (
         <OptionsButtons.RemoveFromPlaylist
           variant={variant}

--- a/src/app/components/table/song-actions.tsx
+++ b/src/app/components/table/song-actions.tsx
@@ -2,6 +2,7 @@ import { Row } from '@tanstack/react-table'
 import { SongMenuOptions } from '@/app/components/song/menu-options'
 import { TableActionButton } from '@/app/components/table/action-button'
 import { TableLikeButton } from '@/app/components/table/like-button'
+import { useAppStore } from '@/store/app.store'
 import { ISong } from '@/types/responses/song'
 
 interface SongTableActionsProps {
@@ -9,6 +10,8 @@ interface SongTableActionsProps {
 }
 
 export function SongTableActions({ row }: SongTableActionsProps) {
+  const hideFavoritesSection = useAppStore().pages.hideFavoritesSection
+
   return (
     <div className="flex gap-1 items-center">
       <TableActionButton
@@ -20,11 +23,13 @@ export function SongTableActions({ row }: SongTableActionsProps) {
           />
         }
       />
-      <TableLikeButton
-        type="song"
-        entityId={row.original.id}
-        starred={typeof row.original.starred === 'string'}
-      />
+      {!hideFavoritesSection && (
+        <TableLikeButton
+          type="song"
+          entityId={row.original.id}
+          starred={typeof row.original.starred === 'string'}
+        />
+      )}
     </div>
   )
 }

--- a/src/app/tables/artists-columns.tsx
+++ b/src/app/tables/artists-columns.tsx
@@ -4,6 +4,7 @@ import { TableLikeButton } from '@/app/components/table/like-button'
 import PlaySongButton from '@/app/components/table/play-button'
 import { DataTableColumnHeader } from '@/app/components/ui/data-table-column-header'
 import i18n from '@/i18n'
+import { useAppStore } from '@/store/app.store'
 import { ColumnDefType } from '@/types/react-table/columnDef'
 import { ISimilarArtist } from '@/types/responses/artist'
 
@@ -15,6 +16,7 @@ const MemoDataTableColumnHeader = memo(
 const MemoTableLikeButton = memo(TableLikeButton)
 
 export function artistsColumns(): ColumnDefType<ISimilarArtist>[] {
+  const hideFavoritesSection = useAppStore().pages.hideFavoritesSection
   return [
     {
       id: 'index',
@@ -70,25 +72,25 @@ export function artistsColumns(): ColumnDefType<ISimilarArtist>[] {
         </MemoDataTableColumnHeader>
       ),
     },
-    {
-      id: 'starred',
-      accessorKey: 'starred',
-      header: '',
-      style: {
-        width: 48,
-        maxWidth: 48,
-      },
-      cell: ({ row }) => {
-        const { starred, id } = row.original
-
-        return (
-          <MemoTableLikeButton
-            type="artist"
-            entityId={id}
-            starred={typeof starred === 'string'}
-          />
-        )
-      },
-    },
+    ...(hideFavoritesSection
+      ? []
+      : [
+          {
+            id: 'starred',
+            accessorKey: 'starred',
+            header: '',
+            style: { width: 48, maxWidth: 48 },
+            cell: ({ row }) => {
+              const { starred, id } = row.original
+              return (
+                <MemoTableLikeButton
+                  type="artist"
+                  entityId={id}
+                  starred={typeof starred === 'string'}
+                />
+              )
+            },
+          },
+        ]),
   ]
 }

--- a/src/app/tables/songs-columns.tsx
+++ b/src/app/tables/songs-columns.tsx
@@ -11,6 +11,7 @@ import { DataTableColumnHeader } from '@/app/components/ui/data-table-column-hea
 import { SimpleTooltip } from '@/app/components/ui/simple-tooltip'
 import i18n from '@/i18n'
 import { ROUTES } from '@/routes/routesList'
+import { useAppStore } from '@/store/app.store'
 import { ColumnDefType } from '@/types/react-table/columnDef'
 import { ISong } from '@/types/responses/song'
 import { formatBitrate } from '@/utils/audioInfo'
@@ -262,11 +263,15 @@ export function songsColumns(): ColumnDefType<ISong>[] {
         maxWidth: 120,
         justifyContent: 'end',
       },
-      header: () => (
-        <MemoSimpleTooltip text={i18n.t('table.columns.favorite')}>
-          <HeartIcon className="w-4 h-4 mr-2" />
-        </MemoSimpleTooltip>
-      ),
+      header: () => {
+        const hideFavoritesSection = useAppStore().pages.hideFavoritesSection
+        if (hideFavoritesSection) return null
+        return (
+          <MemoSimpleTooltip text={i18n.t('table.columns.favorite')}>
+            <HeartIcon className="w-4 h-4 mr-2" />
+          </MemoSimpleTooltip>
+        )
+      },
       cell: ({ row }) => <MemoSongTableActions row={row} />,
     },
   ]

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -728,6 +728,10 @@
         "group": "Sidebar",
         "description": "Show or hide sections in the sidebar."
       },
+      "features": {
+        "group": "Features",
+        "description": "Enable or disable client features"
+      },
       "podcast": {
         "group": "Podcasts",
         "description": "Enable integration with the Aonsoku Podcasts service.",


### PR DESCRIPTION
Closes #385

When the favorites or playlists sections are hidden in Settings > Content, the UI now reflects this globally across the client, not just in the sidebar.
Previously, hiding these sections only removed them from the sidebar library navigation. This change applies the same behavior consistently across the song table, player controls, and context menus.
The toggles have also been migrated out of the "Sidebar" subsection into a new "Features" section under Settings > Content to better communicate that these are global client feature toggles.

**Changes**
- Hide like button in table rows and column headers when favorites are disabled
- Hide album and artist like buttons when favorites are disabled
- Hide like button in fullscreen and mini player when favorites are disabled
- Hide "Add to Playlist" from song context menu and dropdown when playlists is disabled
- Hide "Add to Playlist" from album options dropdown when playlists is disabled
- Hide playlists nav section in sidebar when playlists is disabled
- Moved favorites and playlists toggles to a new "Features" section in Settings > Content
- Added English locale strings for the new "Features" section header

**Why**
This allows users who have disabled favorites or playlists on the server side to have a consistent experience across the entire client, not just the sidebar.