### PR TITLE
fix: support ALAC (m4a) playback via server-side transcoding

### DIFF
--- a/src/app/components/player/player.tsx
+++ b/src/app/components/player/player.tsx
@@ -128,6 +128,8 @@ export function Player() {
   }, [
     getAudioRef,
     isPodcast,
+    isSong,
+    song?.duration,
     podcast,
     setCurrentDuration,
     getCurrentPodcastProgress,

--- a/src/app/components/player/player.tsx
+++ b/src/app/components/player/player.tsx
@@ -104,6 +104,8 @@ export function Player() {
 
     if (!infinityDuration) {
       setCurrentDuration(audioDuration)
+    } else if (isSong && song?.duration) {
+      setCurrentDuration(song.duration)
     }
 
     if (isPodcast && infinityDuration && podcast) {
@@ -238,7 +240,11 @@ export function Player() {
       {isSong && song && (
         <AudioPlayer
           replayGain={trackReplayGain}
-          src={getSongStreamUrl(song.id)}
+          src={getSongStreamUrl(
+              song.id,
+              undefined,
+              song.suffix === 'm4a' ? 'opus' : undefined,
+            )}
           autoPlay={isPlaying}
           audioRef={audioRef}
           loop={loopState === LoopState.One}


### PR DESCRIPTION
## Summary

- When the song suffix is `m4a` (typically ALAC), request the server to transcode to `opus` format, since browsers cannot natively decode ALAC audio.
- Use song metadata duration as fallback when the transcoded stream reports `Infinity` duration, so the progress bar displays the correct total time.

## Changes

Only `src/app/components/player/player.tsx` is modified (2 small changes):

1. Pass `format: 'opus'` to `getSongStreamUrl()` when `song.suffix === 'm4a'`
2. Fall back to `song.duration` from metadata when `audio.duration === Infinity`

## Context

ALAC files use the `.m4a` container format. While AAC `.m4a` files play fine in browsers, ALAC-encoded `.m4a` files cannot be decoded natively. The Subsonic API supports server-side transcoding via the `format` parameter on the `/stream` endpoint, so we leverage that to request `opus` output for `.m4a` files.

## Test plan

- [ ] Play an ALAC (.m4a) song and verify it plays correctly
- [ ] Verify the progress bar shows the correct total duration
- [ ] Play non-m4a songs (FLAC, MP3, etc.) and verify no regressions


🤖 Generated with [Claude Code](https://claude.com/claude-code)