### PR TITLE
feat: Add KDE window control icons

### DIFF
--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -100,3 +100,7 @@ if (process.contextIsolated) {
   // @ts-expect-error (define in dts)
   window.api = api
 }
+
+contextBridge.exposeInMainWorld('envVars', {
+  XDG_CURRENT_DESKTOP: process.env.XDG_CURRENT_DESKTOP
+})

--- a/src/app/components/controls/icons.tsx
+++ b/src/app/components/controls/icons.tsx
@@ -204,4 +204,63 @@ export const Icons = {
       </g>
     </svg>
   ),
+  closeLinuxKDE: (props: JSX.IntrinsicAttributes & SVGProps<SVGSVGElement>) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="none"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <g>
+        <polyline points="3.2806700000000006,3.2806700000000006 20.71939,20.71939" stroke="currentColor" strokeWidth="2" />
+        <polyline points="20.71939,3.2806700000000006 3.2806700000000006,20.71939" stroke="currentColor" strokeWidth="2" />
+      </g>
+    </svg>
+  ),
+  maximizeLinuxKDE: (props: JSX.IntrinsicAttributes & SVGProps<SVGSVGElement>) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="none"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <g>
+        <polyline points="1.1008300000000002,16.35971 12.000029999999999,5.460509999999999 22.89923,16.35971" stroke="currentColor" strokeWidth="2" />
+      </g>
+    </svg>
+  ),
+  maximizeRestoreLinuxKDE: (
+    props: JSX.IntrinsicAttributes & SVGProps<SVGSVGElement>,
+  ) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="none"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <g>
+        <path d="M 1.1008216,12 12.000045,1.1007761 22.899269,12 12.000045,22.899224 1.1008216,12" stroke="currentColor" strokeWidth="2" />
+      </g>
+    </svg>
+  ),
+  minimizeLinuxKDE: (props: JSX.IntrinsicAttributes & SVGProps<SVGSVGElement>) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="none"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <g>
+        <polyline points="1.1008300000000002,7.64035 12.000029999999999,18.53955 22.89923,7.64035" stroke="currentColor" strokeWidth="2" id="polyline1" />
+      </g>
+    </svg>
+  ),
 }

--- a/src/app/components/controls/linux.tsx
+++ b/src/app/components/controls/linux.tsx
@@ -3,6 +3,7 @@ import { useAppWindow } from '@/app/hooks/use-app-window'
 import { cn } from '@/lib/utils'
 import { ControlButton } from './button'
 import { Icons } from './icons'
+import { isKDE } from "@/utils/desktop.ts";
 
 type LinuxProps = ComponentPropsWithoutRef<'div'>
 
@@ -30,23 +31,39 @@ export function Linux({ className, ...props }: LinuxProps) {
         onClick={minimizeWindow}
         className="m-0 aspect-square size-[26px] cursor-default rounded-full p-0 hover:bg-foreground/10 active:bg-foreground/20"
       >
-        <Icons.minimizeLinux className="text-foreground size-[13px] mt-[1px]" />
+        {isKDE ? (
+          <Icons.minimizeLinuxKDE className="text-foreground size-[13px] mt-[1px]" />
+        ) : (
+          <Icons.minimizeLinux className="text-foreground size-[13px] mt-[1px]" />
+        )}
       </ControlButton>
       <ControlButton
         onClick={maximizeWindow}
         className="m-0 aspect-square size-[26px] cursor-default rounded-full p-0 hover:bg-foreground/10 active:bg-foreground/20"
       >
         {!isMaximized ? (
-          <Icons.maximizeLinux className="text-foreground size-3" />
+          isKDE ? (
+            <Icons.maximizeLinuxKDE className="text-foreground size-3" />
+          ) : (
+            <Icons.maximizeLinux className="text-foreground size-3" />
+          )
         ) : (
-          <Icons.maximizeRestoreLinux className="text-foreground size-3" />
+          isKDE ? (
+            <Icons.maximizeRestoreLinuxKDE className="text-foreground size-3" />
+          ) : (
+            <Icons.maximizeRestoreLinux className="text-foreground size-3" />
+          )
         )}
       </ControlButton>
       <ControlButton
         onClick={closeWindow}
         className="m-0 aspect-square size-[26px] cursor-default rounded-full p-0 hover:bg-windows-red group active:bg-windows-red"
       >
-        <Icons.closeLinux className="text-foreground group-hover:text-white size-3" />
+        {isKDE ? (
+          <Icons.closeLinuxKDE className="text-foreground group-hover:text-white size-3" />
+        ) : (
+          <Icons.closeLinux className="text-foreground group-hover:text-white size-3" />
+        )}
       </ControlButton>
     </div>
   )

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -4,6 +4,10 @@ function isCypress(): boolean {
   return (window as { Cypress?: unknown }).Cypress !== undefined
 }
 
+function checkKDE(): boolean {
+  return window.envVars.XDG_CURRENT_DESKTOP.split(':').some((desktop: string) => desktop === 'KDE')
+}
+
 export function isDesktop(): boolean {
   return isElectron && !isCypress()
 }
@@ -15,3 +19,5 @@ export const isDeviceWindows = osName === 'Windows'
 export const isLinux = isDesktop() ? isDeviceLinux : false
 export const isMacOS = isDesktop() ? isDeviceMacOS : false
 export const isWindows = isDesktop() ? isDeviceWindows : false
+
+export const isKDE = isLinux ? checkKDE() : false


### PR DESCRIPTION
I'm vain and I need the window control icons to match the desktop environment.

DE is detected based on `XDG_CURRENT_DESKTOP` environment variable per [freedesktop standard](https://wiki.archlinux.org/title/Environment_variables#Desktop_environment_detection).

Windowed: <img width="381" height="160" alt="windowed" src="https://github.com/user-attachments/assets/75b5c78b-c785-40f5-9a64-a34e3062f8d3" />
Maximized: <img width="362" height="132" alt="maximized" src="https://github.com/user-attachments/assets/13b8e876-9a89-412c-83d2-d2faae4891dd" />
