### PR TITLE
feat: Display radio metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "html-to-text": "^9.0.5",
     "i18next": "^23.16.8",
     "i18next-browser-languagedetector": "^8.0.4",
+    "icecast-metadata-stats": "^0.1.12",
     "idb-keyval": "^6.2.2",
     "immer": "^10.1.1",
     "linkify-it": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       i18next-browser-languagedetector:
         specifier: ^8.0.4
         version: 8.0.4
+      icecast-metadata-stats:
+        specifier: ^0.1.12
+        version: 0.1.12
       idb-keyval:
         specifier: ^6.2.2
         version: 6.2.2
@@ -2235,6 +2238,9 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  codec-parser@2.5.0:
+    resolution: {integrity: sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2918,6 +2924,13 @@ packages:
 
   i18next@23.16.8:
     resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
+
+  icecast-metadata-js@1.2.9:
+    resolution: {integrity: sha512-8YqPrJ4AjM64O28xF9TSUUFczxnTKwXwnIPmZKRxdbaZb6hn0nP+ke1OGNA+UsIfLpNRW4acDDBkIkbynYVQig==}
+
+  icecast-metadata-stats@0.1.12:
+    resolution: {integrity: sha512-qywYIIvxjAmZIFNUXMVZ/IgIJh87z0W6oOmJ5htPw3SUauXcYoY6rRexvzN5Ibct8hXsqoTcB+k8m6Wa53bfJg==}
+    engines: {node: '>=18.0.0'}
 
   iconv-corefoundation@1.1.7:
     resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
@@ -6480,6 +6493,8 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  codec-parser@2.5.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -7390,6 +7405,14 @@ snapshots:
   i18next@23.16.8:
     dependencies:
       '@babel/runtime': 7.27.0
+
+  icecast-metadata-js@1.2.9:
+    dependencies:
+      codec-parser: 2.5.0
+
+  icecast-metadata-stats@0.1.12:
+    dependencies:
+      icecast-metadata-js: 1.2.9
 
   iconv-corefoundation@1.1.7:
     dependencies:

--- a/src/app/components/player/radio-info.tsx
+++ b/src/app/components/player/radio-info.tsx
@@ -1,10 +1,56 @@
 import { RadioIcon } from 'lucide-react'
-import { Fragment } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { MarqueeTitle } from "@/app/components/fullscreen/marquee-title.tsx"
 import { Radio } from '@/types/responses/radios'
+import IcecastMetadataStats from 'icecast-metadata-stats'
 
 export function RadioInfo({ radio }: { radio: Radio | undefined }) {
   const { t } = useTranslation()
+  const [radioMetadata , setRadioMetadata] = useState({title: null, artist: null})
+  const streamUrl = radio?.streamUrl
+
+  useEffect(() => {
+    if (!streamUrl) {
+      setRadioMetadata({title: null, artist: null})
+      return
+    }
+    let iceListener: IcecastMetadataStats
+
+    try {
+      iceListener = new IcecastMetadataStats(streamUrl, {
+        interval: 10,
+        onStats: (stats) => {
+          const streamTitle = stats.StreamTitle ? stats.StreamTitle : stats.icy?.StreamTitle
+          if (streamTitle) {
+            const i = streamTitle.indexOf(' - ')
+
+            if (i < 0) {
+              setRadioMetadata({title: streamTitle.trim(), artist: null})
+            } else {
+              const trackArtist = streamTitle.slice(0, i).trim()
+              const trackTitle = streamTitle.slice(i + 3).trim()
+              setRadioMetadata({title: trackTitle, artist: trackArtist})
+            }
+          } else {
+            setRadioMetadata({title: null, artist: null})
+          }
+        },
+        sources: ['icy'],
+      })
+
+      iceListener.start()
+    } catch {
+      setRadioMetadata({title: null, artist: null})
+    }
+
+    return () => {
+      if (iceListener) {
+        iceListener.stop()
+      }
+      setRadioMetadata({title: null, artist: null})
+    }
+  }, [streamUrl])
 
   return (
     <Fragment>
@@ -15,17 +61,25 @@ export function RadioInfo({ radio }: { radio: Radio | undefined }) {
           data-testid="radio-icon"
         />
       </div>
-      <div className="flex flex-col justify-center">
+      <div className="flex flex-col w-[66%] max-w-full justify-end text-left overflow-hidden">
         {radio ? (
           <Fragment>
-            <span className="text-sm font-medium" data-testid="radio-name">
-              {radio.name}
+            <MarqueeTitle gap="mr-6" >
+              <span className="text-sm font-medium" data-testid="radio-title">
+                { radioMetadata.title && radioMetadata.title !== "" ? radioMetadata.title : "—" }
+              </span>
+            </MarqueeTitle>
+            <span
+              className="text-xs font-light text-muted-foreground"
+              data-testid="radio-artist"
+            >
+              { radioMetadata.artist && radioMetadata.artist !== "" ? radioMetadata.artist : "" }
             </span>
             <span
               className="text-xs font-light text-muted-foreground"
-              data-testid="radio-label"
+              data-testid="radio-name"
             >
-              {t('radios.label')}
+              { radio.name }
             </span>
           </Fragment>
         ) : (

--- a/src/app/components/player/radio-info.tsx
+++ b/src/app/components/player/radio-info.tsx
@@ -1,59 +1,13 @@
 import { RadioIcon } from 'lucide-react'
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import { MarqueeTitle } from "@/app/components/fullscreen/marquee-title.tsx"
 import { Radio } from '@/types/responses/radios'
-import IcecastMetadataStats from 'icecast-metadata-stats'
+import { useRadioMetadata } from '../../hooks/use-radio-metadata'
 
 export function RadioInfo({ radio }: { radio: Radio | undefined }) {
   const { t } = useTranslation()
-  const [radioMetadata , setRadioMetadata] = useState({title: "", artist: ""})
-  const streamUrl = radio?.streamUrl
-
-  useEffect(() => {
-    if (!streamUrl) {
-      setRadioMetadata({artist: "", title: ""})
-      return
-    }
-    let iceListener: IcecastMetadataStats
-    let prevStreamTitle = ""
-
-    try {
-      iceListener = new IcecastMetadataStats(streamUrl, {
-        interval: 10,
-        onStats: (stats) => {
-          const streamTitle = stats.StreamTitle ? stats.StreamTitle : stats.icy?.StreamTitle
-          if (streamTitle && prevStreamTitle !== streamTitle) {
-            prevStreamTitle = streamTitle
-            const i = streamTitle.indexOf(' - ')
-
-            if (i < 0) {
-              setRadioMetadata({title: streamTitle.trim(), artist: ""})
-            } else {
-              const trackArtist = streamTitle.slice(0, i).trim()
-              const trackTitle = streamTitle.slice(i + 3).trim()
-              setRadioMetadata({title: trackTitle, artist: trackArtist})
-            }
-          } else if (prevStreamTitle !== streamTitle) {
-            prevStreamTitle = streamTitle
-            setRadioMetadata({title: "", artist: ""})
-          }
-        },
-        sources: ['icy'],
-      })
-
-      iceListener.start()
-    } catch {
-      setRadioMetadata({title: "", artist: ""})
-    }
-
-    return () => {
-      if (iceListener) {
-        iceListener.stop()
-      }
-      setRadioMetadata({title: "", artist: ""})
-    }
-  }, [streamUrl])
+  const radioMetadata = useRadioMetadata(radio)
 
   return (
     <Fragment>
@@ -66,25 +20,39 @@ export function RadioInfo({ radio }: { radio: Radio | undefined }) {
       </div>
       <div className="flex flex-col w-[66%] max-w-full justify-end text-left overflow-hidden">
         {radio ? (
-          <Fragment>
-            <MarqueeTitle gap="mr-6" >
-              <span className="text-sm font-medium" data-testid="radio-title">
-                { radioMetadata.title !== "" ? radioMetadata.title : "—" }
+          radioMetadata.title !== "" ? (
+            <Fragment>
+              <MarqueeTitle gap="mr-6" >
+                <span className="text-sm font-medium" data-testid="radio-title">
+                  { radioMetadata.title }
+                </span>
+              </MarqueeTitle>
+              <span
+                className="text-xs font-light text-muted-foreground"
+                data-testid="radio-artist"
+              >
+                { radioMetadata.artist }
               </span>
-            </MarqueeTitle>
-            <span
-              className="text-xs font-light text-muted-foreground"
-              data-testid="radio-artist"
-            >
-              { radioMetadata.artist }
-            </span>
-            <span
-              className="text-xs font-light text-muted-foreground"
-              data-testid="radio-name"
-            >
-              { radio.name }
-            </span>
-          </Fragment>
+              <span
+                className="text-xs font-light text-muted-foreground"
+                data-testid="radio-name"
+              >
+                { radio.name }
+              </span>
+            </Fragment>
+          ) : (
+            <Fragment>
+              <span className="text-sm font-medium" data-testid="radio-name">
+                { radio.name }
+              </span>
+                <span
+                  className="text-xs font-light text-muted-foreground"
+                  data-testid="radio-label"
+                >
+                { t('radios.label') }
+              </span>
+            </Fragment>
+          )
         ) : (
           <span className="text-sm font-medium" data-testid="radio-no-playing">
             {t('player.noRadioPlaying')}

--- a/src/app/components/player/radio-info.tsx
+++ b/src/app/components/player/radio-info.tsx
@@ -7,33 +7,36 @@ import IcecastMetadataStats from 'icecast-metadata-stats'
 
 export function RadioInfo({ radio }: { radio: Radio | undefined }) {
   const { t } = useTranslation()
-  const [radioMetadata , setRadioMetadata] = useState({title: null, artist: null})
+  const [radioMetadata , setRadioMetadata] = useState({title: "", artist: ""})
   const streamUrl = radio?.streamUrl
 
   useEffect(() => {
     if (!streamUrl) {
-      setRadioMetadata({title: null, artist: null})
+      setRadioMetadata({artist: "", title: ""})
       return
     }
     let iceListener: IcecastMetadataStats
+    let prevStreamTitle = ""
 
     try {
       iceListener = new IcecastMetadataStats(streamUrl, {
         interval: 10,
         onStats: (stats) => {
           const streamTitle = stats.StreamTitle ? stats.StreamTitle : stats.icy?.StreamTitle
-          if (streamTitle) {
+          if (streamTitle && prevStreamTitle !== streamTitle) {
+            prevStreamTitle = streamTitle
             const i = streamTitle.indexOf(' - ')
 
             if (i < 0) {
-              setRadioMetadata({title: streamTitle.trim(), artist: null})
+              setRadioMetadata({title: streamTitle.trim(), artist: ""})
             } else {
               const trackArtist = streamTitle.slice(0, i).trim()
               const trackTitle = streamTitle.slice(i + 3).trim()
               setRadioMetadata({title: trackTitle, artist: trackArtist})
             }
-          } else {
-            setRadioMetadata({title: null, artist: null})
+          } else if (prevStreamTitle !== streamTitle) {
+            prevStreamTitle = streamTitle
+            setRadioMetadata({title: "", artist: ""})
           }
         },
         sources: ['icy'],
@@ -41,14 +44,14 @@ export function RadioInfo({ radio }: { radio: Radio | undefined }) {
 
       iceListener.start()
     } catch {
-      setRadioMetadata({title: null, artist: null})
+      setRadioMetadata({title: "", artist: ""})
     }
 
     return () => {
       if (iceListener) {
         iceListener.stop()
       }
-      setRadioMetadata({title: null, artist: null})
+      setRadioMetadata({title: "", artist: ""})
     }
   }, [streamUrl])
 
@@ -66,14 +69,14 @@ export function RadioInfo({ radio }: { radio: Radio | undefined }) {
           <Fragment>
             <MarqueeTitle gap="mr-6" >
               <span className="text-sm font-medium" data-testid="radio-title">
-                { radioMetadata.title && radioMetadata.title !== "" ? radioMetadata.title : "—" }
+                { radioMetadata.title !== "" ? radioMetadata.title : "—" }
               </span>
             </MarqueeTitle>
             <span
               className="text-xs font-light text-muted-foreground"
               data-testid="radio-artist"
             >
-              { radioMetadata.artist && radioMetadata.artist !== "" ? radioMetadata.artist : "" }
+              { radioMetadata.artist }
             </span>
             <span
               className="text-xs font-light text-muted-foreground"

--- a/src/app/hooks/use-radio-metadata.tsx
+++ b/src/app/hooks/use-radio-metadata.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { Radio } from '@/types/responses/radios'
+import IcecastMetadataStats from 'icecast-metadata-stats'
+
+export const useRadioMetadata = (radio: Radio | undefined) => {
+  const streamUrl = radio?.streamUrl
+  const [radioMetadata , setRadioMetadata] = useState({title: "", artist: ""})
+
+  useEffect(() => {
+    if (!streamUrl) {
+      setRadioMetadata({artist: "", title: ""})
+      return
+    }
+    let iceListener: IcecastMetadataStats
+    let prevStreamTitle = ""
+
+    try {
+      iceListener = new IcecastMetadataStats(streamUrl, {
+        interval: 10,
+        onStats: (stats) => {
+          const streamTitle = stats.StreamTitle ? stats.StreamTitle : stats.icy?.StreamTitle
+          if (streamTitle && prevStreamTitle !== streamTitle) {
+            prevStreamTitle = streamTitle
+            const i = streamTitle.indexOf(' - ')
+
+            if (i < 0) {
+              setRadioMetadata({title: streamTitle.trim(), artist: ""})
+            } else {
+              const trackArtist = streamTitle.slice(0, i).trim()
+              const trackTitle = streamTitle.slice(i + 3).trim()
+              setRadioMetadata({title: trackTitle, artist: trackArtist})
+            }
+          } else if (prevStreamTitle !== streamTitle) {
+            prevStreamTitle = streamTitle
+            setRadioMetadata({title: "", artist: ""})
+          }
+        },
+        sources: ['icy'],
+      })
+
+      iceListener.start()
+    } catch {
+      setRadioMetadata({title: "", artist: ""})
+    }
+
+    return () => {
+      if (iceListener) {
+        iceListener.stop()
+      }
+      setRadioMetadata({title: "", artist: ""})
+    }
+  }, [streamUrl])
+
+  return radioMetadata
+}


### PR DESCRIPTION
Addresses #309 

Displays now playing metadata for radio via [Icecast](https://npm.io/package/icecast-metadata-stats). Track title and artist is parsed from the stream title.

<img width="497" height="151" alt="radio_icy_metadata" src="https://github.com/user-attachments/assets/91049948-16d4-43cd-ae16-fb622cc459a9" />

<img width="386" height="144" alt="radio_icy_metadata2" src="https://github.com/user-attachments/assets/3e1500a8-9c95-401b-9fad-186ca2ded5be" />

