### PR TITLE
feat: resend Discord RPC on seek or loop

### DIFF
--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -1061,6 +1061,15 @@ usePlayerStore.subscribe(
   },
 )
 
+usePlayerStore.subscribe(
+  (state) => state.playerProgress.progress,
+  (progress, prevProgress) => {
+    if (Math.abs(progress - prevProgress) > 0.02) {
+      discordRpc.sendCurrentSong()
+    }
+  },
+)
+
 usePlayerStore.subscribe((state, prevState) => {
   const currentSong = state.songlist.currentSong ?? null
 


### PR DESCRIPTION
closes #404

**Changes**
- Added a subscription to "playerProgress.progress" that detects when progress jumps by more than 2% in either direction, then updates discord RPC with the corrected timestamps. This subscription also applies to looping songs.