### PR TITLE
feat: Support OS v2 songLyrics

### DIFF
--- a/cypress/fixtures/lyrics/README.md
+++ b/cypress/fixtures/lyrics/README.md
@@ -1,0 +1,19 @@
+# Lyrics Test Fixtures
+
+OpenSubsonic v1/v2 lyric response fixtures for Cypress component tests.
+
+| File | Description | Used by |
+|------|-------------|---------|
+| v1-line-only.json | V1 plain lyrics response (no cueLine, no kind) | T11, T14 |
+| v2-with-cues.json | Full v2 with ASCII cues + start+end on every cue | T11, T13, T14 |
+| v2-no-cues.json | V2 server but no cueLine (no ELRC source) | T11, T14 |
+| v2-cjk-korean.json | Korean text with correct UTF-8 byte offsets | T11, T14 |
+| v2-rtl-arabic.json | Arabic RTL text with byte offsets | T11 |
+| v2-no-end.json | All cues missing `end` (all-or-none fill test) | T11, T13 |
+| v2-multi-agent-same-value.json | Two agents, identical text (D3 stack test) | T11, T14 |
+| v2-multi-agent-different-value.json | Two agents, different concurrent text (K-pop ad-libs) | T11, T13, T14 |
+| v2-multi-language.json | translation first, main second (picker test) | T14 |
+| v2-empty.json | Empty structuredLyrics array | T14 |
+| v2-oob-cueline.json | cueLine index 99 in a 3-line response (OOB filter) | T13 |
+| v2-bad-byte-range.json | byteStart > byteEnd (defensive guard test) | T11 |
+| v2-with-offset.json | offset: -100 at structuredLyric level | T13 |

--- a/cypress/fixtures/lyrics/v1-line-only.json
+++ b/cypress/fixtures/lyrics/v1-line-only.json
@@ -1,0 +1,11 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.13.0",
+    "lyrics": {
+      "artist": "Test Artist",
+      "title": "Test Song",
+      "value": "[00:01.00] Sunlight through the trees\n[00:05.00] Echo in the valley\n[00:09.00] Morning breaks again"
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-bad-byte-range.json
+++ b/cypress/fixtures/lyrics/v2-bad-byte-range.json
@@ -1,0 +1,46 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "main",
+          "line": [
+            {
+              "start": 0,
+              "value": "Test line"
+            }
+          ],
+          "cueLine": [
+            {
+              "index": 0,
+              "value": "Test line",
+              "start": 0,
+              "end": 2000,
+              "cue": [
+                {
+                  "start": 0,
+                  "end": 1000,
+                  "value": "Test",
+                  "byteStart": 10,
+                  "byteEnd": 2
+                },
+                {
+                  "start": 1000,
+                  "end": 2000,
+                  "value": "line",
+                  "byteStart": 5,
+                  "byteEnd": 8
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-cjk-korean.json
+++ b/cypress/fixtures/lyrics/v2-cjk-korean.json
@@ -1,0 +1,81 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "kor",
+          "synced": true,
+          "kind": "main",
+          "line": [
+            {
+              "start": 2747,
+              "value": "눈을 뜬 순간"
+            }
+          ],
+          "cueLine": [
+            {
+              "index": 0,
+              "value": "눈을 뜬 순간",
+              "start": 2747,
+              "end": 6214,
+              "cue": [
+                {
+                  "start": 2747,
+                  "end": 3018,
+                  "value": "눈",
+                  "byteStart": 0,
+                  "byteEnd": 2
+                },
+                {
+                  "start": 3018,
+                  "end": 3179,
+                  "value": "을",
+                  "byteStart": 3,
+                  "byteEnd": 5
+                },
+                {
+                  "start": 3179,
+                  "end": 3582,
+                  "value": " ",
+                  "byteStart": 6,
+                  "byteEnd": 6
+                },
+                {
+                  "start": 3582,
+                  "end": 4100,
+                  "value": "뜬",
+                  "byteStart": 7,
+                  "byteEnd": 9
+                },
+                {
+                  "start": 4100,
+                  "end": 4500,
+                  "value": " ",
+                  "byteStart": 10,
+                  "byteEnd": 10
+                },
+                {
+                  "start": 4500,
+                  "end": 5200,
+                  "value": "순",
+                  "byteStart": 11,
+                  "byteEnd": 13
+                },
+                {
+                  "start": 5200,
+                  "end": 6214,
+                  "value": "간",
+                  "byteStart": 14,
+                  "byteEnd": 16
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-empty-line-short-gap.json
+++ b/cypress/fixtures/lyrics/v2-empty-line-short-gap.json
@@ -1,0 +1,53 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "main",
+          "line": [
+            { "start": 1000, "value": "First line" },
+            { "start": 2000, "value": "" },
+            { "start": 4000, "value": "After short pause" }
+          ],
+          "cueLine": [
+            {
+              "index": 0,
+              "value": "First line",
+              "start": 1000,
+              "end": 2000,
+              "cue": [
+                {
+                  "start": 1000,
+                  "end": 2000,
+                  "value": "First line",
+                  "byteStart": 0,
+                  "byteEnd": 9
+                }
+              ]
+            },
+            {
+              "index": 2,
+              "value": "After short pause",
+              "start": 4000,
+              "end": 6000,
+              "cue": [
+                {
+                  "start": 4000,
+                  "end": 6000,
+                  "value": "After short pause",
+                  "byteStart": 0,
+                  "byteEnd": 16
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-empty.json
+++ b/cypress/fixtures/lyrics/v2-empty.json
@@ -1,0 +1,10 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": []
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-multi-agent-different-value.json
+++ b/cypress/fixtures/lyrics/v2-multi-agent-different-value.json
@@ -1,0 +1,152 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "main",
+          "agents": [
+            {
+              "id": "lead",
+              "role": "main",
+              "name": "Lead Vocal"
+            },
+            {
+              "id": "bg",
+              "role": "bg",
+              "name": "Background"
+            }
+          ],
+          "line": [
+            {
+              "start": 1000,
+              "value": "Don't worry bout a thing"
+            }
+          ],
+          "cueLine": [
+            {
+              "index": 0,
+              "agentId": "lead",
+              "value": "Don't worry bout a thing",
+              "start": 1000,
+              "end": 5000,
+              "cue": [
+                {
+                  "start": 1000,
+                  "end": 1600,
+                  "value": "Don't",
+                  "byteStart": 0,
+                  "byteEnd": 4
+                },
+                {
+                  "start": 1600,
+                  "end": 1900,
+                  "value": " ",
+                  "byteStart": 5,
+                  "byteEnd": 5
+                },
+                {
+                  "start": 1900,
+                  "end": 2600,
+                  "value": "worry",
+                  "byteStart": 6,
+                  "byteEnd": 10
+                },
+                {
+                  "start": 2600,
+                  "end": 2900,
+                  "value": " ",
+                  "byteStart": 11,
+                  "byteEnd": 11
+                },
+                {
+                  "start": 2900,
+                  "end": 3400,
+                  "value": "bout",
+                  "byteStart": 12,
+                  "byteEnd": 15
+                },
+                {
+                  "start": 3400,
+                  "end": 3700,
+                  "value": " ",
+                  "byteStart": 16,
+                  "byteEnd": 16
+                },
+                {
+                  "start": 3700,
+                  "end": 3900,
+                  "value": "a",
+                  "byteStart": 17,
+                  "byteEnd": 17
+                },
+                {
+                  "start": 3900,
+                  "end": 4200,
+                  "value": " ",
+                  "byteStart": 18,
+                  "byteEnd": 18
+                },
+                {
+                  "start": 4200,
+                  "end": 5000,
+                  "value": "thing",
+                  "byteStart": 19,
+                  "byteEnd": 23
+                }
+              ]
+            },
+            {
+              "index": 0,
+              "agentId": "bg",
+              "value": "Oh oh oh",
+              "start": 1200,
+              "end": 5000,
+              "cue": [
+                {
+                  "start": 1200,
+                  "end": 2000,
+                  "value": "Oh",
+                  "byteStart": 0,
+                  "byteEnd": 1
+                },
+                {
+                  "start": 2000,
+                  "end": 2300,
+                  "value": " ",
+                  "byteStart": 2,
+                  "byteEnd": 2
+                },
+                {
+                  "start": 2300,
+                  "end": 3200,
+                  "value": "oh",
+                  "byteStart": 3,
+                  "byteEnd": 4
+                },
+                {
+                  "start": 3200,
+                  "end": 3500,
+                  "value": " ",
+                  "byteStart": 5,
+                  "byteEnd": 5
+                },
+                {
+                  "start": 3500,
+                  "end": 5000,
+                  "value": "oh",
+                  "byteStart": 6,
+                  "byteEnd": 7
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-multi-agent-overlapping-indices.json
+++ b/cypress/fixtures/lyrics/v2-multi-agent-overlapping-indices.json
@@ -1,0 +1,118 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "main",
+          "agents": [
+            { "id": "lead", "role": "main", "name": "Lead" },
+            { "id": "echo", "role": "voice", "name": "Echo" },
+            { "id": "choir", "role": "bg", "name": "Choir" }
+          ],
+          "line": [
+            { "start": 1000, "value": "First line" },
+            { "start": 1500, "value": "Echo over" },
+            { "start": 2500, "value": "Choir joins" }
+          ],
+          "cueLine": [
+            {
+              "index": 0,
+              "agentId": "lead",
+              "start": 1000,
+              "end": 2200,
+              "value": "First line",
+              "cue": [
+                {
+                  "start": 1000,
+                  "end": 1500,
+                  "value": "First",
+                  "byteStart": 0,
+                  "byteEnd": 4
+                },
+                {
+                  "start": 1500,
+                  "end": 1700,
+                  "value": " ",
+                  "byteStart": 5,
+                  "byteEnd": 5
+                },
+                {
+                  "start": 1700,
+                  "end": 2200,
+                  "value": "line",
+                  "byteStart": 6,
+                  "byteEnd": 9
+                }
+              ]
+            },
+            {
+              "index": 1,
+              "agentId": "echo",
+              "start": 1500,
+              "end": 3000,
+              "value": "Echo over",
+              "cue": [
+                {
+                  "start": 1500,
+                  "end": 1900,
+                  "value": "Echo",
+                  "byteStart": 0,
+                  "byteEnd": 3
+                },
+                {
+                  "start": 1900,
+                  "end": 2100,
+                  "value": " ",
+                  "byteStart": 4,
+                  "byteEnd": 4
+                },
+                {
+                  "start": 2100,
+                  "end": 3000,
+                  "value": "over",
+                  "byteStart": 5,
+                  "byteEnd": 8
+                }
+              ]
+            },
+            {
+              "index": 2,
+              "agentId": "choir",
+              "start": 2500,
+              "end": 4000,
+              "value": "Choir joins",
+              "cue": [
+                {
+                  "start": 2500,
+                  "end": 2900,
+                  "value": "Choir",
+                  "byteStart": 0,
+                  "byteEnd": 4
+                },
+                {
+                  "start": 2900,
+                  "end": 3100,
+                  "value": " ",
+                  "byteStart": 5,
+                  "byteEnd": 5
+                },
+                {
+                  "start": 3100,
+                  "end": 4000,
+                  "value": "joins",
+                  "byteStart": 6,
+                  "byteEnd": 10
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-multi-agent-same-value.json
+++ b/cypress/fixtures/lyrics/v2-multi-agent-same-value.json
@@ -1,0 +1,124 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "main",
+          "agents": [
+            {
+              "id": "lead",
+              "role": "main",
+              "name": "Lead Vocal"
+            },
+            {
+              "id": "bg",
+              "role": "bg",
+              "name": "Background"
+            }
+          ],
+          "line": [
+            {
+              "start": 1000,
+              "value": "Together we stand"
+            }
+          ],
+          "cueLine": [
+            {
+              "index": 0,
+              "agentId": "lead",
+              "value": "Together we stand",
+              "start": 1000,
+              "end": 4000,
+              "cue": [
+                {
+                  "start": 1000,
+                  "end": 1800,
+                  "value": "Together",
+                  "byteStart": 0,
+                  "byteEnd": 7
+                },
+                {
+                  "start": 1800,
+                  "end": 2100,
+                  "value": " ",
+                  "byteStart": 8,
+                  "byteEnd": 8
+                },
+                {
+                  "start": 2100,
+                  "end": 2500,
+                  "value": "we",
+                  "byteStart": 9,
+                  "byteEnd": 10
+                },
+                {
+                  "start": 2500,
+                  "end": 2800,
+                  "value": " ",
+                  "byteStart": 11,
+                  "byteEnd": 11
+                },
+                {
+                  "start": 2800,
+                  "end": 4000,
+                  "value": "stand",
+                  "byteStart": 12,
+                  "byteEnd": 16
+                }
+              ]
+            },
+            {
+              "index": 0,
+              "agentId": "bg",
+              "value": "Together we stand",
+              "start": 1000,
+              "end": 4000,
+              "cue": [
+                {
+                  "start": 1000,
+                  "end": 1800,
+                  "value": "Together",
+                  "byteStart": 0,
+                  "byteEnd": 7
+                },
+                {
+                  "start": 1800,
+                  "end": 2100,
+                  "value": " ",
+                  "byteStart": 8,
+                  "byteEnd": 8
+                },
+                {
+                  "start": 2100,
+                  "end": 2500,
+                  "value": "we",
+                  "byteStart": 9,
+                  "byteEnd": 10
+                },
+                {
+                  "start": 2500,
+                  "end": 2800,
+                  "value": " ",
+                  "byteStart": 11,
+                  "byteEnd": 11
+                },
+                {
+                  "start": 2800,
+                  "end": 4000,
+                  "value": "stand",
+                  "byteStart": 12,
+                  "byteEnd": 16
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-multi-language.json
+++ b/cypress/fixtures/lyrics/v2-multi-language.json
@@ -1,0 +1,41 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "translation",
+          "line": [
+            {
+              "start": 2747,
+              "value": "The moment I opened my eyes"
+            },
+            {
+              "start": 6214,
+              "value": "Everything had changed"
+            }
+          ]
+        },
+        {
+          "lang": "kor",
+          "synced": true,
+          "kind": "main",
+          "line": [
+            {
+              "start": 2747,
+              "value": "눈을 뜬 순간"
+            },
+            {
+              "start": 6214,
+              "value": "모든 게 달라졌어"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-no-cues.json
+++ b/cypress/fixtures/lyrics/v2-no-cues.json
@@ -1,0 +1,26 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "main",
+          "line": [
+            {
+              "start": 1000,
+              "value": "Sunlight through the trees"
+            },
+            {
+              "start": 5000,
+              "value": "Echo in the valley"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-no-end.json
+++ b/cypress/fixtures/lyrics/v2-no-end.json
@@ -1,0 +1,74 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "main",
+          "line": [
+            {
+              "start": 0,
+              "value": "Rivers run to sea"
+            }
+          ],
+          "cueLine": [
+            {
+              "index": 0,
+              "value": "Rivers run to sea",
+              "start": 0,
+              "end": 2000,
+              "cue": [
+                {
+                  "start": 0,
+                  "value": "Rivers",
+                  "byteStart": 0,
+                  "byteEnd": 5
+                },
+                {
+                  "start": 500,
+                  "value": " ",
+                  "byteStart": 6,
+                  "byteEnd": 6
+                },
+                {
+                  "start": 700,
+                  "value": "run",
+                  "byteStart": 7,
+                  "byteEnd": 9
+                },
+                {
+                  "start": 1000,
+                  "value": " ",
+                  "byteStart": 10,
+                  "byteEnd": 10
+                },
+                {
+                  "start": 1100,
+                  "value": "to",
+                  "byteStart": 11,
+                  "byteEnd": 12
+                },
+                {
+                  "start": 1400,
+                  "value": " ",
+                  "byteStart": 13,
+                  "byteEnd": 13
+                },
+                {
+                  "start": 1500,
+                  "value": "sea",
+                  "byteStart": 14,
+                  "byteEnd": 16
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-oob-cueline.json
+++ b/cypress/fixtures/lyrics/v2-oob-cueline.json
@@ -1,0 +1,47 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "main",
+          "line": [
+            {
+              "start": 0,
+              "value": "Line one"
+            },
+            {
+              "start": 2000,
+              "value": "Line two"
+            },
+            {
+              "start": 4000,
+              "value": "Line three"
+            }
+          ],
+          "cueLine": [
+            {
+              "index": 99,
+              "value": "This should be ignored",
+              "start": 0,
+              "end": 1000,
+              "cue": [
+                {
+                  "start": 0,
+                  "end": 500,
+                  "value": "This",
+                  "byteStart": 0,
+                  "byteEnd": 3
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-rtl-arabic.json
+++ b/cypress/fixtures/lyrics/v2-rtl-arabic.json
@@ -1,0 +1,53 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "ara",
+          "synced": true,
+          "kind": "main",
+          "line": [
+            {
+              "start": 1000,
+              "value": "السلام"
+            }
+          ],
+          "cueLine": [
+            {
+              "index": 0,
+              "value": "السلام",
+              "start": 1000,
+              "end": 3000,
+              "cue": [
+                {
+                  "start": 1000,
+                  "end": 1400,
+                  "value": "ال",
+                  "byteStart": 0,
+                  "byteEnd": 3
+                },
+                {
+                  "start": 1400,
+                  "end": 1800,
+                  "value": "سل",
+                  "byteStart": 4,
+                  "byteEnd": 7
+                },
+                {
+                  "start": 1800,
+                  "end": 3000,
+                  "value": "ام",
+                  "byteStart": 8,
+                  "byteEnd": 11
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-with-cues.json
+++ b/cypress/fixtures/lyrics/v2-with-cues.json
@@ -1,0 +1,163 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "main",
+          "displayArtist": "Test Artist",
+          "displayTitle": "Test Song",
+          "line": [
+            {
+              "start": 1000,
+              "value": "Sunlight through"
+            },
+            {
+              "start": 5000,
+              "value": "Echo in the valley"
+            },
+            {
+              "start": 9000,
+              "value": "Morning breaks again"
+            }
+          ],
+          "cueLine": [
+            {
+              "index": 0,
+              "value": "Sunlight through",
+              "start": 1000,
+              "end": 4999,
+              "cue": [
+                {
+                  "start": 1000,
+                  "end": 1800,
+                  "value": "Sunlight",
+                  "byteStart": 0,
+                  "byteEnd": 7
+                },
+                {
+                  "start": 1800,
+                  "end": 2200,
+                  "value": " ",
+                  "byteStart": 8,
+                  "byteEnd": 8
+                },
+                {
+                  "start": 2200,
+                  "end": 4999,
+                  "value": "through",
+                  "byteStart": 9,
+                  "byteEnd": 15
+                }
+              ]
+            },
+            {
+              "index": 1,
+              "value": "Echo in the valley",
+              "start": 5000,
+              "end": 8999,
+              "cue": [
+                {
+                  "start": 5000,
+                  "end": 5500,
+                  "value": "Echo",
+                  "byteStart": 0,
+                  "byteEnd": 3
+                },
+                {
+                  "start": 5500,
+                  "end": 5800,
+                  "value": " ",
+                  "byteStart": 4,
+                  "byteEnd": 4
+                },
+                {
+                  "start": 5800,
+                  "end": 6100,
+                  "value": "in",
+                  "byteStart": 5,
+                  "byteEnd": 6
+                },
+                {
+                  "start": 6100,
+                  "end": 6400,
+                  "value": " ",
+                  "byteStart": 7,
+                  "byteEnd": 7
+                },
+                {
+                  "start": 6400,
+                  "end": 6700,
+                  "value": "the",
+                  "byteStart": 8,
+                  "byteEnd": 10
+                },
+                {
+                  "start": 6700,
+                  "end": 6900,
+                  "value": " ",
+                  "byteStart": 11,
+                  "byteEnd": 11
+                },
+                {
+                  "start": 6900,
+                  "end": 8999,
+                  "value": "valley",
+                  "byteStart": 12,
+                  "byteEnd": 17
+                }
+              ]
+            },
+            {
+              "index": 2,
+              "value": "Morning breaks again",
+              "start": 9000,
+              "end": 12000,
+              "cue": [
+                {
+                  "start": 9000,
+                  "end": 9800,
+                  "value": "Morning",
+                  "byteStart": 0,
+                  "byteEnd": 6
+                },
+                {
+                  "start": 9800,
+                  "end": 10200,
+                  "value": " ",
+                  "byteStart": 7,
+                  "byteEnd": 7
+                },
+                {
+                  "start": 10200,
+                  "end": 11000,
+                  "value": "breaks",
+                  "byteStart": 8,
+                  "byteEnd": 13
+                },
+                {
+                  "start": 11000,
+                  "end": 11300,
+                  "value": " ",
+                  "byteStart": 14,
+                  "byteEnd": 14
+                },
+                {
+                  "start": 11300,
+                  "end": 12000,
+                  "value": "again",
+                  "byteStart": 15,
+                  "byteEnd": 19
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-with-empty-lines.json
+++ b/cypress/fixtures/lyrics/v2-with-empty-lines.json
@@ -1,0 +1,53 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "main",
+          "line": [
+            { "start": 1000, "value": "First line" },
+            { "start": 2000, "value": "" },
+            { "start": 7000, "value": "After silence" }
+          ],
+          "cueLine": [
+            {
+              "index": 0,
+              "value": "First line",
+              "start": 1000,
+              "end": 2000,
+              "cue": [
+                {
+                  "start": 1000,
+                  "end": 2000,
+                  "value": "First line",
+                  "byteStart": 0,
+                  "byteEnd": 9
+                }
+              ]
+            },
+            {
+              "index": 2,
+              "value": "After silence",
+              "start": 7000,
+              "end": 9000,
+              "cue": [
+                {
+                  "start": 7000,
+                  "end": 9000,
+                  "value": "After silence",
+                  "byteStart": 0,
+                  "byteEnd": 12
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/lyrics/v2-with-offset.json
+++ b/cypress/fixtures/lyrics/v2-with-offset.json
@@ -1,0 +1,54 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "openSubsonic": true,
+    "lyricsList": {
+      "structuredLyrics": [
+        {
+          "lang": "eng",
+          "synced": true,
+          "kind": "main",
+          "offset": -100,
+          "line": [
+            {
+              "start": 2000,
+              "value": "Offset line"
+            }
+          ],
+          "cueLine": [
+            {
+              "index": 0,
+              "value": "Offset line",
+              "start": 2000,
+              "end": 5000,
+              "cue": [
+                {
+                  "start": 2000,
+                  "end": 2800,
+                  "value": "Offset",
+                  "byteStart": 0,
+                  "byteEnd": 5
+                },
+                {
+                  "start": 2800,
+                  "end": 3100,
+                  "value": " ",
+                  "byteStart": 6,
+                  "byteEnd": 6
+                },
+                {
+                  "start": 3100,
+                  "end": 5000,
+                  "value": "line",
+                  "byteStart": 7,
+                  "byteEnd": 10
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/app/components/fullscreen/lyrics.cy.tsx
+++ b/src/app/components/fullscreen/lyrics.cy.tsx
@@ -1,0 +1,592 @@
+import { subsonic } from '@/service/subsonic'
+import { useAppStore } from '@/store/app.store'
+import { usePlayerStore } from '@/store/player.store'
+import type { ISong } from '@/types/responses/song'
+import { LyricsTab } from './lyrics'
+
+// ---------------------------------------------------------------------------
+// Shared LyricsResult mock shapes
+// ---------------------------------------------------------------------------
+
+// Word mode — v2 structuredLyric with cueLine data
+const wordMock = {
+  value: '[00:01.00] Sunlight through the trees',
+  lang: 'eng',
+  artist: 'Test Artist',
+  title: 'Test Song',
+  structuredLyric: {
+    synced: true,
+    kind: 'main',
+    lang: 'eng',
+    line: [{ start: 1000, value: 'Sunlight through the trees' }],
+    cueLine: [
+      {
+        index: 0,
+        value: 'Sunlight through the trees',
+        start: 1000,
+        end: 4999,
+        cue: [
+          {
+            start: 1000,
+            end: 1800,
+            value: 'Sunlight',
+            byteStart: 0,
+            byteEnd: 7,
+          },
+        ],
+      },
+    ],
+  },
+}
+
+// Line mode — synced LRC string, no cueLine
+const lineMock = {
+  value:
+    '[00:01.00] Sunlight through the trees\n[00:05.00] Echo in the valley',
+  lang: 'eng',
+  artist: 'Test Artist',
+  title: 'Test Song',
+}
+
+// Plain mode — NOT LRC format (no [00: prefix)
+const plainMock = {
+  value: 'Sunlight through the trees\nEcho in the valley',
+  lang: 'eng',
+  artist: 'Test Artist',
+  title: 'Test Song',
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setExtensions(v2: boolean) {
+  useAppStore.setState((state) => ({
+    ...state,
+    data: {
+      ...state.data,
+      extensionsSupported: v2 ? { songLyrics: [1, 2] } : { songLyrics: [1] },
+    },
+  }))
+}
+
+// Each test gets a unique queryKey because the singleton QueryClient (in
+// cypress/support/component.tsx) caches by ['get-lyrics', artist, title,
+// duration] (see lyrics.tsx). Mutating artist + title per test ensures the
+// stub is freshly invoked.
+let testCounter = 0
+
+// ---------------------------------------------------------------------------
+// Spec
+// ---------------------------------------------------------------------------
+
+describe('LyricsTab mode routing', () => {
+  beforeEach(() => {
+    testCounter += 1
+    const tag = `lyrics-t14-${testCounter}-${Date.now()}`
+
+    cy.fixture('songs/song.json').then((song: ISong) => {
+      const uniqueSong: ISong = {
+        ...song,
+        id: tag,
+        title: `${song.title} ${tag}`,
+        artist: `${song.artist} ${tag}`,
+      }
+      usePlayerStore.getState().actions.setSongList([uniqueSong], 0)
+    })
+  })
+
+  afterEach(() => {
+    useAppStore.setState((state) => ({
+      ...state,
+      data: { ...state.data, extensionsSupported: undefined },
+    }))
+    usePlayerStore.setState((state) => ({
+      ...state,
+      settings: {
+        ...state.settings,
+        lyrics: { ...state.settings.lyrics, preferSyncedLyrics: false },
+      },
+    }))
+  })
+
+  // 1. Word mode when v2 + cueLine data + preferSyncedLyrics=true
+  it('routes to word mode when v2 extension + cueLine + preferSyncedLyrics=true', () => {
+    setExtensions(true)
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: true },
+      },
+    }))
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(wordMock)
+
+    cy.mount(<LyricsTab />)
+
+    cy.get('[data-testid="lyrics-mode"]').should(
+      'have.attr',
+      'data-mode',
+      'word',
+    )
+    cy.get('[data-testid="word-sync-lyrics-box"]').should('exist')
+  })
+
+  // 2. Line mode when v2 server but no cueLine data
+  it('falls back to line mode when v2 server returns no cueLine', () => {
+    setExtensions(true)
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: true },
+      },
+    }))
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(lineMock)
+
+    cy.mount(<LyricsTab />)
+
+    cy.get('[data-testid="lyrics-mode"]').should(
+      'have.attr',
+      'data-mode',
+      'line',
+    )
+    cy.get('#sync-lyrics-box').should('exist')
+    cy.get('[data-testid="word-sync-lyrics-box"]').should('not.exist')
+  })
+
+  // 3. Line mode when v1-only server (regression guard)
+  it('uses line mode when server only advertises songLyrics v1', () => {
+    setExtensions(false)
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: true },
+      },
+    }))
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(lineMock)
+
+    cy.mount(<LyricsTab />)
+
+    cy.get('[data-testid="lyrics-mode"]').should(
+      'have.attr',
+      'data-mode',
+      'line',
+    )
+  })
+
+  // 4. Plain mode when preferSyncedLyrics=false (D1 guard)
+  it('shows plain mode when preferSyncedLyrics is false, ignoring cueLine data (D1)', () => {
+    setExtensions(true)
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: false },
+      },
+    }))
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(plainMock)
+
+    cy.mount(<LyricsTab />)
+
+    cy.get('[data-testid="lyrics-mode"]').should(
+      'have.attr',
+      'data-mode',
+      'plain',
+    )
+    cy.get('[data-testid="word-sync-lyrics-box"]').should('not.exist')
+  })
+
+  // 5. No word mode when no extension data
+  it('does not use word mode when extensionsSupported is empty', () => {
+    useAppStore.setState((s) => ({
+      ...s,
+      data: { ...s.data, extensionsSupported: {} },
+    }))
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: true },
+      },
+    }))
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(lineMock)
+
+    cy.mount(<LyricsTab />)
+
+    cy.get('[data-testid="lyrics-mode"]').should(
+      'have.attr',
+      'data-mode',
+      'line',
+    )
+  })
+
+  // 6. Loading state shown while query is in flight
+  it('shows loading message while lyrics are being fetched', () => {
+    setExtensions(true)
+    cy.stub(subsonic.lyrics, 'getLyrics').returns(
+      new Promise<never>(() => {}),
+    )
+
+    cy.mount(<LyricsTab />)
+
+    // Loading state — no lyrics-mode div
+    cy.get('[data-testid="lyrics-mode"]').should('not.exist')
+  })
+
+  // 7. No lyrics message when service returns undefined
+  it('shows no-lyrics message when service returns undefined', () => {
+    setExtensions(true)
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: true },
+      },
+    }))
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(undefined)
+
+    cy.mount(<LyricsTab />)
+
+    cy.get('[data-testid="lyrics-mode"]').should('not.exist')
+  })
+
+  // 8. Multi-agent: two agent sub-rows render stacked (D3-revised)
+  it('renders two stacked sub-rows for multi-agent structuredLyric', () => {
+    setExtensions(true)
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: true },
+      },
+    }))
+    const multiAgentMock = {
+      value: '[00:01.00] Together we stand',
+      lang: 'eng',
+      artist: 'Test',
+      title: 'Test',
+      structuredLyric: {
+        synced: true,
+        kind: 'main',
+        lang: 'eng',
+        agents: [
+          { id: 'lead', role: 'main' },
+          { id: 'bg', role: 'bg' },
+        ],
+        line: [{ start: 1000, value: 'Together we stand' }],
+        cueLine: [
+          {
+            index: 0,
+            agentId: 'lead',
+            value: 'Together we stand',
+            start: 1000,
+            end: 4000,
+            cue: [
+              {
+                start: 1000,
+                end: 4000,
+                value: 'Together we stand',
+                byteStart: 0,
+                byteEnd: 16,
+              },
+            ],
+          },
+          {
+            index: 0,
+            agentId: 'bg',
+            value: 'Together we stand',
+            start: 1000,
+            end: 4000,
+            cue: [
+              {
+                start: 1000,
+                end: 4000,
+                value: 'Together we stand',
+                byteStart: 0,
+                byteEnd: 16,
+              },
+            ],
+          },
+        ],
+      },
+    }
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(multiAgentMock)
+
+    cy.mount(<LyricsTab />)
+
+    cy.get('[data-testid="lyrics-mode"]').should(
+      'have.attr',
+      'data-mode',
+      'word',
+    )
+    cy.get('[data-testid="word-line-0"]').children('p').should('have.length', 2)
+    cy.get('[data-display-order="0"]').should('not.have.class', 'opacity-70')
+    cy.get('[data-display-order="1"]')
+      .should('have.class', 'opacity-70')
+      .and('have.class', 'text-sm')
+  })
+
+  // 9. Multi-agent different values: concurrent vocalists both visible
+  it('renders both lead and background concurrent text when values differ', () => {
+    setExtensions(true)
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: true },
+      },
+    }))
+    const diffMock = {
+      value: "[00:01.00] Don't worry bout a thing",
+      lang: 'eng',
+      artist: 'Test',
+      title: 'Test',
+      structuredLyric: {
+        synced: true,
+        kind: 'main',
+        lang: 'eng',
+        agents: [
+          { id: 'lead', role: 'main' },
+          { id: 'bg', role: 'bg' },
+        ],
+        line: [{ start: 1000, value: "Don't worry bout a thing" }],
+        cueLine: [
+          {
+            index: 0,
+            agentId: 'lead',
+            value: "Don't worry bout a thing",
+            start: 1000,
+            end: 5000,
+            cue: [
+              {
+                start: 1000,
+                end: 5000,
+                value: "Don't worry bout a thing",
+                byteStart: 0,
+                byteEnd: 23,
+              },
+            ],
+          },
+          {
+            index: 0,
+            agentId: 'bg',
+            value: 'Oh oh oh',
+            start: 1200,
+            end: 5000,
+            cue: [
+              {
+                start: 1200,
+                end: 5000,
+                value: 'Oh oh oh',
+                byteStart: 0,
+                byteEnd: 7,
+              },
+            ],
+          },
+        ],
+      },
+    }
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(diffMock)
+
+    cy.mount(<LyricsTab />)
+
+    cy.get('[data-testid="word-line-0"]').children('p').should('have.length', 2)
+    cy.get('[data-agent-role="main"]').should('exist')
+    cy.get('[data-agent-role="bg"]').should('exist')
+  })
+
+  // 10. Multi-agent without agents[] (positional fallback)
+  it('renders stacked sub-rows even when no agents[] declared (positional key fallback)', () => {
+    setExtensions(true)
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: true },
+      },
+    }))
+    const noAgentsMock = {
+      value: '[00:01.00] Test line',
+      lang: 'eng',
+      artist: 'Test',
+      title: 'Test',
+      structuredLyric: {
+        synced: true,
+        kind: 'main',
+        lang: 'eng',
+        line: [{ start: 1000, value: 'Test line' }],
+        cueLine: [
+          {
+            index: 0,
+            value: 'Test line',
+            start: 1000,
+            end: 3000,
+            cue: [
+              {
+                start: 1000,
+                end: 3000,
+                value: 'Test line',
+                byteStart: 0,
+                byteEnd: 8,
+              },
+            ],
+          },
+          {
+            index: 0,
+            value: 'Harmony',
+            start: 1200,
+            end: 3000,
+            cue: [
+              {
+                start: 1200,
+                end: 3000,
+                value: 'Harmony',
+                byteStart: 0,
+                byteEnd: 6,
+              },
+            ],
+          },
+        ],
+      },
+    }
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(noAgentsMock)
+
+    cy.mount(<LyricsTab />)
+
+    cy.get('[data-testid="word-line-0"]').children('p').should('have.length', 2)
+    // Keys use positional fallback: "0:pos0" and "0:pos1"
+    cy.get('[data-testid^="word-line-0-cueline-0:pos"]').should(
+      'have.length',
+      2,
+    )
+  })
+
+  // 11. OOB cueLine.index — graceful (container renders null → word mode chosen but empty)
+  it('handles OOB cueLine.index gracefully without crashing', () => {
+    setExtensions(true)
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: true },
+      },
+    }))
+    const oobMock = {
+      value: '[00:00.00] Line one',
+      lang: 'eng',
+      artist: 'Test',
+      title: 'Test',
+      structuredLyric: {
+        synced: true,
+        kind: 'main',
+        lang: 'eng',
+        line: [{ start: 0, value: 'Line one' }],
+        cueLine: [
+          {
+            index: 99,
+            value: 'OOB',
+            start: 0,
+            end: 1000,
+            cue: [
+              {
+                start: 0,
+                end: 500,
+                value: 'OOB',
+                byteStart: 0,
+                byteEnd: 2,
+              },
+            ],
+          },
+        ],
+      },
+    }
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(oobMock)
+
+    cy.mount(<LyricsTab />)
+
+    // word mode chosen (raw cueLine has cues), but normalizer filters OOB
+    // → container returns null. The lyrics-mode div still has data-mode="word".
+    cy.get('[data-testid="lyrics-mode"]').should(
+      'have.attr',
+      'data-mode',
+      'word',
+    )
+  })
+
+  // 12. Bad byte-range cue falls back to cue.value (no crash)
+  it('handles bad byte-range cue (byteStart > byteEnd) without crashing', () => {
+    setExtensions(true)
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: true },
+      },
+    }))
+    const badByteMock = {
+      value: '[00:00.00] Test line',
+      lang: 'eng',
+      artist: 'Test',
+      title: 'Test',
+      structuredLyric: {
+        synced: true,
+        kind: 'main',
+        lang: 'eng',
+        line: [{ start: 0, value: 'Test line' }],
+        cueLine: [
+          {
+            index: 0,
+            value: 'Test line',
+            start: 0,
+            end: 2000,
+            cue: [
+              {
+                start: 0,
+                end: 1000,
+                value: 'Test',
+                byteStart: 10,
+                byteEnd: 2,
+              },
+            ],
+          },
+        ],
+      },
+    }
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(badByteMock)
+
+    cy.mount(<LyricsTab />)
+
+    cy.get('[data-testid="lyrics-mode"]').should(
+      'have.attr',
+      'data-mode',
+      'word',
+    )
+    // Falls back to cue.value — "Test" renders without crash
+    cy.get('[data-testid="word-sync-lyrics-box"]').should('exist')
+  })
+
+  // 13. Regression: line mode still works end-to-end (SyncedLyrics renders)
+  it('regression: line-only synced lyrics still render via SyncedLyrics (react-lrc)', () => {
+    setExtensions(false)
+    usePlayerStore.setState((s) => ({
+      ...s,
+      settings: {
+        ...s.settings,
+        lyrics: { ...s.settings.lyrics, preferSyncedLyrics: true },
+      },
+    }))
+    cy.stub(subsonic.lyrics, 'getLyrics').resolves(lineMock)
+
+    cy.mount(<LyricsTab />)
+
+    cy.get('[data-testid="lyrics-mode"]').should(
+      'have.attr',
+      'data-mode',
+      'line',
+    )
+    cy.get('#sync-lyrics-box').should('exist')
+    cy.get('[data-testid="word-sync-lyrics-box"]').should('not.exist')
+  })
+})

--- a/src/app/components/fullscreen/lyrics.tsx
+++ b/src/app/components/fullscreen/lyrics.tsx
@@ -10,12 +10,17 @@ import {
 } from '@/app/components/ui/scroll-area'
 import { subsonic } from '@/service/subsonic'
 import { useLang } from '@/store/lang.store'
-import { usePlayerRef, usePlayerSonglist } from '@/store/player.store'
+import {
+  useLyricsSettings,
+  usePlayerRef,
+  usePlayerSonglist,
+} from '@/store/player.store'
 import { ILyric } from '@/types/responses/song'
-import { queryKeys } from '@/utils/queryKeys'
+import { getServerExtensions } from '@/utils/servers'
+import { WordLevelLyricsContainer } from './word-level-lyrics'
 
 // disambiguates chinese language code to the user's locale if set
-function resolveLyricsLang(
+export function resolveLyricsLang(
   lyricsLang: string | undefined,
   appLocale: string,
 ): string | undefined {
@@ -31,11 +36,13 @@ interface LyricProps {
 export function LyricsTab() {
   const { currentSong } = usePlayerSonglist()
   const { t } = useTranslation()
+  const { songLyricsV2Enabled } = getServerExtensions()
+  const { preferWordLevelLyrics } = useLyricsSettings()
 
   const { id, artist, title, duration } = currentSong
 
   const { data: lyrics, isLoading } = useQuery({
-    queryKey: [queryKeys.song.lyrics, artist, title, duration],
+    queryKey: ['get-lyrics', id, artist, title, duration],
     queryFn: () =>
       subsonic.lyrics.getLyrics({
         id,
@@ -43,6 +50,7 @@ export function LyricsTab() {
         title,
         duration,
       }),
+    enabled: !!id,
   })
 
   const noLyricsFound = t('fullscreen.noLyrics')
@@ -51,10 +59,35 @@ export function LyricsTab() {
   if (isLoading) {
     return <CenteredMessage>{loadingLyrics}</CenteredMessage>
   } else if (lyrics && lyrics.value) {
+    const hasWordData =
+      songLyricsV2Enabled &&
+      preferWordLevelLyrics &&
+      !!lyrics.structuredLyric?.cueLine?.some((cl) =>
+        cl.cue.some((c) => c.start != null),
+      )
+    if (hasWordData && lyrics.structuredLyric) {
+      return (
+        <div
+          data-testid="lyrics-mode"
+          data-mode="word"
+          className="w-full h-full"
+        >
+          <WordLevelLyricsContainer structuredLyric={lyrics.structuredLyric} />
+        </div>
+      )
+    }
     return areLyricsSynced(lyrics) ? (
-      <SyncedLyrics lyrics={lyrics} />
+      <div data-testid="lyrics-mode" data-mode="line" className="w-full h-full">
+        <SyncedLyrics lyrics={lyrics} />
+      </div>
     ) : (
-      <UnsyncedLyrics lyrics={lyrics} />
+      <div
+        data-testid="lyrics-mode"
+        data-mode="plain"
+        className="w-full h-full"
+      >
+        <UnsyncedLyrics lyrics={lyrics} />
+      </div>
     )
   } else {
     return <CenteredMessage>{noLyricsFound}</CenteredMessage>

--- a/src/app/components/fullscreen/word-level-lyrics/container.cy.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/container.cy.tsx
@@ -1,0 +1,327 @@
+import { useState } from 'react'
+import { findLineIdx } from '@/hooks/use-raf-active-cue'
+import { usePlayerStore } from '@/store/player.store'
+import type { IStructuredLyric } from '@/types/responses/song'
+import { WordLevelLyricsContainer } from './container'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface FakeAudio {
+  currentTime: number
+  duration: number
+}
+
+interface FixtureShape {
+  'subsonic-response': {
+    lyricsList: {
+      structuredLyrics: IStructuredLyric[]
+    }
+  }
+}
+
+function loadStructuredLyric(
+  fixtureName: string,
+): Cypress.Chainable<IStructuredLyric> {
+  return cy
+    .fixture<FixtureShape>(`lyrics/${fixtureName}`)
+    .then((fx) => {
+      const list = fx['subsonic-response'].lyricsList.structuredLyrics
+      return list.find((l) => l.kind === 'main') ?? list[0]
+    })
+}
+
+function installFakeAudio(): FakeAudio {
+  const fakeAudio: FakeAudio = { currentTime: 0, duration: 300 }
+  usePlayerStore
+    .getState()
+    .actions.setAudioPlayerRef(fakeAudio as unknown as HTMLAudioElement)
+  return fakeAudio
+}
+
+// Wrapper used by the unmount lifecycle test — flipping `mounted` triggers
+// React unmount of the container, which fires the rAF cleanup path.
+function MountToggle({
+  structuredLyric,
+}: {
+  structuredLyric: IStructuredLyric
+}) {
+  const [mounted, setMounted] = useState(true)
+  return (
+    <>
+      <button
+        data-testid="toggle-unmount"
+        type="button"
+        onClick={() => setMounted(false)}
+      >
+        Unmount
+      </button>
+      {mounted && (
+        <WordLevelLyricsContainer structuredLyric={structuredLyric} />
+      )}
+    </>
+  )
+}
+
+// Wrapper used by the song-change rerender test — flipping the lyric prop
+// while keeping the same WordLevelLyricsContainer instance mounted.
+function LyricSwitcher({
+  lyricA,
+  lyricB,
+}: {
+  lyricA: IStructuredLyric
+  lyricB: IStructuredLyric
+}) {
+  const [useB, setUseB] = useState(false)
+  return (
+    <>
+      <button
+        data-testid="switch-lyric"
+        type="button"
+        onClick={() => setUseB(true)}
+      >
+        Switch
+      </button>
+      <WordLevelLyricsContainer
+        structuredLyric={useB ? lyricB : lyricA}
+      />
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Spec
+// ---------------------------------------------------------------------------
+
+describe('WordLevelLyricsContainer (T13)', () => {
+  let fakeAudio: FakeAudio
+
+  beforeEach(() => {
+    fakeAudio = installFakeAudio()
+  })
+
+  afterEach(() => {
+    // Remove any test-set 'hidden' override on document.
+    if (Object.prototype.hasOwnProperty.call(document, 'hidden')) {
+      delete (document as unknown as { hidden?: boolean }).hidden
+    }
+    // Clear the audio ref from the store so spies/handles don't leak.
+    usePlayerStore.setState((state) => {
+      state.playerState.audioPlayerRef = null
+    })
+  })
+
+  // 1
+  it('mounts and renders the scroll container', () => {
+    loadStructuredLyric('v2-with-cues').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+      cy.getByTestId('word-sync-lyrics-box').should('exist')
+    })
+  })
+
+  // 2
+  it('rAF is registered on mount', () => {
+    cy.spy(window, 'requestAnimationFrame').as('raf')
+    loadStructuredLyric('v2-with-cues').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+      cy.get('@raf').its('callCount').should('be.gte', 1)
+    })
+  })
+
+  // 3
+  it('rAF is cancelled on unmount — no post-unmount callbacks', () => {
+    cy.spy(window, 'cancelAnimationFrame').as('caf')
+    loadStructuredLyric('v2-with-cues').then((lyric) => {
+      cy.mount(<MountToggle structuredLyric={lyric} />)
+      cy.getByTestId('word-sync-lyrics-box').should('exist')
+
+      // Trigger React unmount of the container.
+      cy.getByTestId('toggle-unmount').click()
+      cy.getByTestId('word-sync-lyrics-box').should('not.exist')
+
+      cy.get('@caf').its('callCount').should('be.gte', 1)
+    })
+  })
+
+  // 4
+  it('hasWordTiming=false → container renders null', () => {
+    loadStructuredLyric('v2-no-cues').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+      cy.getByTestId('word-sync-lyrics-box').should('not.exist')
+    })
+  })
+
+  // 5
+  it('active line changes when audio time advances past a line start', () => {
+    loadStructuredLyric('v2-with-cues').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+
+      // Initial state: no line active → line 0 has opacity-50.
+      cy.getByTestId('word-line-0').should('have.class', 'opacity-50')
+
+      cy.then(() => {
+        fakeAudio.currentTime = 1.1 // 1100 ms > line[0].start (1000 ms)
+      })
+      cy.wait(50)
+      cy.getByTestId('word-line-0').should('have.class', 'opacity-100')
+    })
+  })
+
+  // 6
+  it('active word changes when audio time enters a cue interval', () => {
+    loadStructuredLyric('v2-with-cues').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+      cy.then(() => {
+        fakeAudio.currentTime = 1.05 // inside cue 0 (1000–1800 ms)
+      })
+      cy.wait(50)
+      cy.get('[data-testid="word-0-0:pos0-0"]').should(
+        'have.class',
+        'text-primary',
+      )
+    })
+  })
+
+  // 7
+  it('click-to-seek sets playerRef.currentTime', () => {
+    loadStructuredLyric('v2-with-cues').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+
+      // Activate line 0 so the word span is interactive.
+      cy.then(() => {
+        fakeAudio.currentTime = 1.05
+      })
+      cy.wait(50)
+
+      cy.get('[data-testid="word-0-0:pos0-0"]').click()
+      cy.then(() => {
+        // cue[0].start = 1000 ms → 1.0 s.
+        expect(fakeAudio.currentTime).to.equal(1.0)
+      })
+    })
+  })
+
+  // 8
+  it('hasWordTiming=true → renders WordLevelLyricsView', () => {
+    loadStructuredLyric('v2-with-cues').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+      cy.getByTestId('word-sync-lyrics-box').should('exist')
+      cy.getByTestId('word-line-0').should('exist')
+      cy.getByTestId('word-line-1').should('exist')
+      cy.getByTestId('word-line-2').should('exist')
+    })
+  })
+
+  // 9
+  it('document.hidden = true → rAF does not update active state', () => {
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => true,
+    })
+
+    loadStructuredLyric('v2-with-cues').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+      cy.then(() => {
+        fakeAudio.currentTime = 1.1
+      })
+      // Wait long enough for several rAF ticks; state should NOT update.
+      cy.wait(100)
+      cy.getByTestId('word-line-0').should('have.class', 'opacity-50')
+      cy.getByTestId('word-line-0').should('not.have.class', 'opacity-100')
+    })
+  })
+
+  // 10
+  it('multi-agent: both lead and bg cues highlighted independently', () => {
+    loadStructuredLyric('v2-multi-agent-different-value').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+      cy.then(() => {
+        // Lead cue 0: 1000–1600 ms. BG cue 0: 1200–2000 ms.
+        // 1.3 s sits inside both.
+        fakeAudio.currentTime = 1.3
+      })
+      cy.wait(50)
+
+      cy.get('[data-testid="word-0-0:lead-0"]').should(
+        'have.attr',
+        'data-state',
+        'active',
+      )
+      cy.get('[data-testid="word-0-0:bg-0"]').should(
+        'have.attr',
+        'data-state',
+        'active',
+      )
+    })
+  })
+
+  // 11
+  it('no active cue (before any line start) yields no active span', () => {
+    loadStructuredLyric('v2-with-cues').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+      cy.then(() => {
+        fakeAudio.currentTime = 0.5 // 500 ms, before line[0].start (1000 ms)
+      })
+      cy.wait(50)
+      cy.get('[data-state="active"]').should('not.exist')
+    })
+  })
+
+  // 12
+  it('Task 4 hook smoke: findLineIdx binary search', () => {
+    expect(findLineIdx([0, 1000, 2500, 4000], -100)).to.equal(-1)
+    expect(findLineIdx([0, 1000, 2500, 4000], 0)).to.equal(0)
+    expect(findLineIdx([0, 1000, 2500, 4000], 999)).to.equal(0)
+    expect(findLineIdx([0, 1000, 2500, 4000], 1000)).to.equal(1)
+    expect(findLineIdx([0, 1000, 2500, 4000], 3000)).to.equal(2)
+    expect(findLineIdx([0, 1000, 2500, 4000], 10_000)).to.equal(3)
+    expect(findLineIdx([], 500)).to.equal(-1)
+  })
+
+  // 13
+  it('song change (new structuredLyric prop) resets active state', () => {
+    loadStructuredLyric('v2-with-cues').then((lyricA) => {
+      loadStructuredLyric('v2-with-offset').then((lyricB) => {
+        cy.mount(<LyricSwitcher lyricA={lyricA} lyricB={lyricB} />)
+
+        // Activate line 1 of lyricA.
+        cy.then(() => {
+          fakeAudio.currentTime = 5.1 // > line[1].start (5000 ms)
+        })
+        cy.wait(50)
+        cy.getByTestId('word-line-1').should('have.class', 'opacity-100')
+
+        // Switch to lyricB (only 1 line, line[0].start = 1900 ms after offset).
+        cy.then(() => {
+          fakeAudio.currentTime = 0
+        })
+        cy.getByTestId('switch-lyric').click()
+        cy.wait(50)
+
+        // lyricB has only one line; word-line-1 must not exist.
+        cy.getByTestId('word-line-1').should('not.exist')
+        // line 0 of lyricB must not be stuck-active from lyricA's line 1.
+        cy.getByTestId('word-line-0').should('have.class', 'opacity-50')
+      })
+    })
+  })
+
+  // 14
+  it('offset applied: cue.start adjusted by offset in v2-with-offset fixture', () => {
+    loadStructuredLyric('v2-with-offset').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+      // offset = -100; raw cue.start = 2000 → effective 1900 ms.
+      // currentTime = 1.95 s = 1950 ms → inside [1900, 2700).
+      cy.then(() => {
+        fakeAudio.currentTime = 1.95
+      })
+      cy.wait(50)
+      cy.get('[data-testid="word-0-0:pos0-0"]').should(
+        'have.attr',
+        'data-state',
+        'active',
+      )
+    })
+  })
+})

--- a/src/app/components/fullscreen/word-level-lyrics/container.cy.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/container.cy.tsx
@@ -324,4 +324,65 @@ describe('WordLevelLyricsContainer (T13)', () => {
       )
     })
   })
+
+  // 15
+  it('cluster: cross-index concurrent voices both go data-state=active when t sits in their overlap window', () => {
+    loadStructuredLyric('v2-multi-agent-overlapping-indices').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+      // Line 0 (lead): 1000-2200. Line 1 (echo): 1500-3000.
+      // 1.7 s sits inside both lines AND inside lead cue 2 (1700-2200) AND echo cue 0 (1500-1900).
+      cy.then(() => {
+        fakeAudio.currentTime = 1.7
+      })
+      cy.wait(50)
+      cy.get('[data-testid="word-line-0"]').should(
+        'have.attr',
+        'data-active',
+        'true',
+      )
+      cy.get('[data-testid="word-line-1"]').should(
+        'have.attr',
+        'data-active',
+        'true',
+      )
+      cy.get('[data-testid="word-0-0:lead-2"]').should(
+        'have.attr',
+        'data-state',
+        'active',
+      )
+      cy.get('[data-testid="word-1-1:echo-0"]').should(
+        'have.attr',
+        'data-state',
+        'active',
+      )
+    })
+  })
+
+  // 16
+  it('cluster anchor shift: when first cluster line ends and a later one starts, data-active set updates without stranding the previous concurrent voice', () => {
+    loadStructuredLyric('v2-multi-agent-overlapping-indices').then((lyric) => {
+      cy.mount(<WordLevelLyricsContainer structuredLyric={lyric} />)
+      // 2.7 s: line 0 (lead) has ended (end=2200), line 1 (echo, 1500-3000)
+      // and line 2 (choir, 2500-4000) both still active.
+      cy.then(() => {
+        fakeAudio.currentTime = 2.7
+      })
+      cy.wait(50)
+      cy.get('[data-testid="word-line-0"]').should(
+        'have.attr',
+        'data-active',
+        'false',
+      )
+      cy.get('[data-testid="word-line-1"]').should(
+        'have.attr',
+        'data-active',
+        'true',
+      )
+      cy.get('[data-testid="word-line-2"]').should(
+        'have.attr',
+        'data-active',
+        'true',
+      )
+    })
+  })
 })

--- a/src/app/components/fullscreen/word-level-lyrics/container.cy.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/container.cy.tsx
@@ -178,7 +178,7 @@ describe('WordLevelLyricsContainer (T13)', () => {
       cy.wait(50)
       cy.get('[data-testid="word-0-0:pos0-0"]').should(
         'have.class',
-        'text-primary',
+        'karaoke-fill',
       )
     })
   })

--- a/src/app/components/fullscreen/word-level-lyrics/container.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/container.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { isSafari } from 'react-device-detect'
-import { useRafActiveCue } from '@/hooks/use-raf-active-cue'
+import { type RafTickInfo, useRafActiveCue } from '@/hooks/use-raf-active-cue'
 import { useWordSeek } from '@/hooks/use-word-seek'
 import { useLang } from '@/store/lang.store'
 import { usePlayerRef } from '@/store/player.store'
@@ -40,11 +40,49 @@ export function WordLevelLyricsContainer({
     [playerRef],
   )
 
+  // Per-cue <span> registry. Each rendered cue span registers/unregisters
+  // itself via `registerWordRef`. We use a Map so writes are O(1); the keys
+  // mirror view.tsx's `${i}|${cueLine.key}|${cueIdx}` format.
+  const wordRefs = useRef<Map<string, HTMLSpanElement>>(new Map())
+  const registerWordRef = useCallback(
+    (key: string, el: HTMLSpanElement | null) => {
+      if (el) wordRefs.current.set(key, el)
+      else wordRefs.current.delete(key)
+    },
+    [],
+  )
+
+  // Karaoke wipe progress channel. Fires every animation frame from
+  // useRafActiveCue. Writes `--fill` directly to the active cue's <span> DOM
+  // node — NOT via React state — so smooth 60fps fill costs zero re-renders.
+  // Only the active cue(s) get a write; past/future cues lack the
+  // `.karaoke-fill` class so their `--fill` value is inert.
+  const handleTick = useCallback(
+    ({ t, activeLineIdx: lineIdx, activeCueByKey: cueByKey }: RafTickInfo) => {
+      if (lineIdx < 0) return
+      const line = normalized.lines[lineIdx]
+      if (!line) return
+      for (const cueLine of line.cueLines) {
+        const cueIdx = cueByKey[cueLine.key]
+        if (cueIdx == null || cueIdx < 0) continue
+        const cue = cueLine.cues[cueIdx]
+        if (!cue) continue
+        const duration = Math.max(1, cue.end - cue.start)
+        const pct = Math.max(0, Math.min(1, (t - cue.start) / duration))
+        const el = wordRefs.current.get(`${lineIdx}|${cueLine.key}|${cueIdx}`)
+        if (el) el.style.setProperty('--fill', `${pct * 100}%`)
+      }
+    },
+    [normalized],
+  )
+
+  // 60fps active-index tracking + karaoke wipe tick.
   const { activeLineIdx, activeCueByKey, lastVisitedCueByKey } =
     useRafActiveCue({
       lines: normalized.lines,
       getCurrentTimeMs,
       enabled: enabled && normalized.hasWordTiming,
+      onTick: handleTick,
     })
 
   const onWordClick = useWordSeek()
@@ -122,6 +160,7 @@ export function WordLevelLyricsContainer({
       resolvedLang={resolvedLang}
       scrollContainerRef={scrollContainerRef}
       lineRefs={lineRefs}
+      registerWordRef={registerWordRef}
     />
   )
 }

--- a/src/app/components/fullscreen/word-level-lyrics/container.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/container.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { isSafari } from 'react-device-detect'
+import { useRafActiveCue } from '@/hooks/use-raf-active-cue'
+import { useWordSeek } from '@/hooks/use-word-seek'
+import { useLang } from '@/store/lang.store'
+import { usePlayerRef } from '@/store/player.store'
+import type { IStructuredLyric } from '@/types/responses/song'
+import { normalizeStructuredLyric } from '@/utils/wordTiming'
+import { resolveLyricsLang } from '../lyrics'
+import { WordLevelLyricsView } from './view'
+
+const SCROLL_RECOVERY_MS = 1500
+
+export interface WordLevelLyricsContainerProps {
+  structuredLyric: IStructuredLyric
+  /** When false, disables rAF polling (e.g. component not visible). Defaults to true. */
+  enabled?: boolean
+}
+
+export function WordLevelLyricsContainer({
+  structuredLyric,
+  enabled = true,
+}: WordLevelLyricsContainerProps) {
+  // Normalise once; re-normalise only when the raw data reference changes.
+  const normalized = useMemo(
+    () => normalizeStructuredLyric(structuredLyric),
+    [structuredLyric],
+  )
+
+  const { langCode } = useLang()
+  const resolvedLang = useMemo(
+    () => resolveLyricsLang(normalized.lang, langCode),
+    [normalized.lang, langCode],
+  )
+
+  // Audio time getter — passed to the rAF hook so the hook stays store-agnostic.
+  const playerRef = usePlayerRef()
+  const getCurrentTimeMs = useCallback(
+    () => (playerRef?.currentTime ?? 0) * 1000,
+    [playerRef],
+  )
+
+  const { activeLineIdx, activeCueByKey, lastVisitedCueByKey } =
+    useRafActiveCue({
+      lines: normalized.lines,
+      getCurrentTimeMs,
+      enabled: enabled && normalized.hasWordTiming,
+    })
+
+  const onWordClick = useWordSeek()
+
+  // Refs for DOM nodes.
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const lineRefs = useRef<(HTMLDivElement | null)[]>([])
+
+  // Auto-scroll with recovery — mirrors react-lrc's recoverAutoScrollInterval={1500}.
+  const userScrollGuardRef = useRef({ pausedUntilMs: 0 })
+  const programmaticScrollRef = useRef(false)
+
+  // Attach scroll listener to detect user-initiated scrolls.
+  useEffect(() => {
+    const el = scrollContainerRef.current
+    if (!el) return
+    const onScroll = () => {
+      // Ignore scroll events caused by our own programmatic scrollIntoView.
+      if (programmaticScrollRef.current) return
+      userScrollGuardRef.current.pausedUntilMs =
+        performance.now() + SCROLL_RECOVERY_MS
+    }
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => el.removeEventListener('scroll', onScroll)
+  }, [])
+
+  // Scroll active line into view when it changes. Fires once per activeLineIdx
+  // change — never per rAF tick — because the effect depends on activeLineIdx.
+  useEffect(() => {
+    if (activeLineIdx < 0) return
+    if (performance.now() < userScrollGuardRef.current.pausedUntilMs) return
+
+    const lineEl = lineRefs.current[activeLineIdx]
+    const scrollEl = scrollContainerRef.current
+    if (!lineEl || !scrollEl) return
+
+    programmaticScrollRef.current = true
+    lineEl.scrollIntoView({
+      behavior: isSafari ? 'auto' : 'smooth',
+      block: 'center',
+    })
+
+    // A smooth scroll fires many `scroll` events asynchronously over ~300-500ms.
+    // We must keep `programmaticScrollRef.current` true until the scroll really
+    // finishes, otherwise the scroll-listener mistakes those events for a user
+    // scroll and pauses auto-scroll for SCROLL_RECOVERY_MS — causing the next
+    // line transition to be silently skipped.
+    const clearFlag = () => {
+      programmaticScrollRef.current = false
+    }
+
+    // Prefer the native `scrollend` event when available
+    // Otherwise fall back to a timeout long enough to
+    // cover typical smooth-scroll durations across browsers.
+    if ('onscrollend' in scrollEl) {
+      scrollEl.addEventListener('scrollend', clearFlag, { once: true })
+      return () => {
+        scrollEl.removeEventListener('scrollend', clearFlag)
+      }
+    }
+    const handle = setTimeout(clearFlag, 700)
+    return () => clearTimeout(handle)
+  }, [activeLineIdx])
+
+  // Defensive: should never be mounted without word timing, but bail out safely.
+  if (!normalized.hasWordTiming) return null
+
+  return (
+    <WordLevelLyricsView
+      data={normalized}
+      activeLineIdx={activeLineIdx}
+      activeCueByKey={activeCueByKey}
+      lastVisitedCueByKey={lastVisitedCueByKey}
+      onWordClick={onWordClick}
+      resolvedLang={resolvedLang}
+      scrollContainerRef={scrollContainerRef}
+      lineRefs={lineRefs}
+    />
+  )
+}

--- a/src/app/components/fullscreen/word-level-lyrics/container.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/container.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { isSafari } from 'react-device-detect'
 import { type RafTickInfo, useRafActiveCue } from '@/hooks/use-raf-active-cue'
 import { useWordSeek } from '@/hooks/use-word-seek'
@@ -52,6 +52,30 @@ export function WordLevelLyricsContainer({
     [],
   )
 
+  // Per-dot <span> registry for instrumental break indicators. Same DOM-direct
+  // --fill pattern as wordRefs; keys match view.tsx's `${break.key}|${dotIdx}`.
+  const dotRefs = useRef<Map<string, HTMLSpanElement>>(new Map())
+  const registerDotRef = useCallback(
+    (key: string, el: HTMLSpanElement | null) => {
+      if (el) dotRefs.current.set(key, el)
+      else dotRefs.current.delete(key)
+    },
+    [],
+  )
+
+  // Tracks which break dot is currently active (if any). State changes only on
+  // dot transitions (~1Hz during a break), keeping React re-renders minimal.
+  // The ref shadow lets handleTick read the previous value without a closure
+  // over state, mirroring the lineIdxRef/cueByKeyRef pattern in useRafActiveCue.
+  const [activeBreakInfo, setActiveBreakInfo] = useState<{
+    breakKey: string
+    dotIdx: number
+  } | null>(null)
+  const activeBreakInfoRef = useRef<{
+    breakKey: string
+    dotIdx: number
+  } | null>(null)
+
   // Karaoke wipe progress channel. Fires every animation frame from
   // useRafActiveCue. Writes `--fill` directly to the active cue's <span> DOM
   // node — NOT via React state — so smooth 60fps fill costs zero re-renders.
@@ -59,18 +83,51 @@ export function WordLevelLyricsContainer({
   // `.karaoke-fill` class so their `--fill` value is inert.
   const handleTick = useCallback(
     ({ t, activeLineIdx: lineIdx, activeCueByKey: cueByKey }: RafTickInfo) => {
-      if (lineIdx < 0) return
-      const line = normalized.lines[lineIdx]
-      if (!line) return
-      for (const cueLine of line.cueLines) {
-        const cueIdx = cueByKey[cueLine.key]
-        if (cueIdx == null || cueIdx < 0) continue
-        const cue = cueLine.cues[cueIdx]
-        if (!cue) continue
-        const duration = Math.max(1, cue.end - cue.start)
-        const pct = Math.max(0, Math.min(1, (t - cue.start) / duration))
-        const el = wordRefs.current.get(`${lineIdx}|${cueLine.key}|${cueIdx}`)
+      if (lineIdx >= 0) {
+        const line = normalized.lines[lineIdx]
+        if (line) {
+          for (const cueLine of line.cueLines) {
+            const cueIdx = cueByKey[cueLine.key]
+            if (cueIdx == null || cueIdx < 0) continue
+            const cue = cueLine.cues[cueIdx]
+            if (!cue) continue
+            const duration = Math.max(1, cue.end - cue.start)
+            const pct = Math.max(0, Math.min(1, (t - cue.start) / duration))
+            const el = wordRefs.current.get(
+              `${lineIdx}|${cueLine.key}|${cueIdx}`,
+            )
+            if (el) el.style.setProperty('--fill', `${pct * 100}%`)
+          }
+        }
+      }
+
+      // Break dot --fill: linear scan over breaks is fine — N is small (one
+      // per gap >= 3s) and most songs have <10 breaks. Same DOM-direct write
+      // pattern as cues; only the active dot has .karaoke-fill applied so
+      // writes to other dots' --fill are inert.
+      let newBreakInfo: { breakKey: string; dotIdx: number } | null = null
+      for (const brk of normalized.breaks) {
+        if (t < brk.start || t >= brk.end) continue
+        const durationPerDot = (brk.end - brk.start) / brk.dotCount
+        const dotIdx = Math.min(
+          brk.dotCount - 1,
+          Math.max(0, Math.floor((t - brk.start) / durationPerDot)),
+        )
+        newBreakInfo = { breakKey: brk.key, dotIdx }
+        const dotStart = brk.start + dotIdx * durationPerDot
+        const pct = Math.max(0, Math.min(1, (t - dotStart) / durationPerDot))
+        const el = dotRefs.current.get(`${brk.key}|${dotIdx}`)
         if (el) el.style.setProperty('--fill', `${pct * 100}%`)
+        break
+      }
+
+      const prev = activeBreakInfoRef.current
+      if (
+        prev?.breakKey !== newBreakInfo?.breakKey ||
+        prev?.dotIdx !== newBreakInfo?.dotIdx
+      ) {
+        activeBreakInfoRef.current = newBreakInfo
+        setActiveBreakInfo(newBreakInfo)
       }
     },
     [normalized],
@@ -90,6 +147,7 @@ export function WordLevelLyricsContainer({
   // Refs for DOM nodes.
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const lineRefs = useRef<(HTMLDivElement | null)[]>([])
+  const breakContainerRefs = useRef<Map<string, HTMLDivElement>>(new Map())
 
   // Auto-scroll with recovery — mirrors react-lrc's recoverAutoScrollInterval={1500}.
   const userScrollGuardRef = useRef({ pausedUntilMs: 0 })
@@ -147,6 +205,39 @@ export function WordLevelLyricsContainer({
     return () => clearTimeout(handle)
   }, [activeLineIdx])
 
+  // Mirror of the line scroll effect for instrumental breaks. Keyed only on
+  // breakKey (not dotIdx) so we scroll on break entry, not every ~1s dot
+  // transition. When activeBreakInfo flips to null at break end, the next
+  // line's scroll effect picks up naturally.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on break entry only, not per-dot
+  useEffect(() => {
+    if (!activeBreakInfo) return
+    if (performance.now() < userScrollGuardRef.current.pausedUntilMs) return
+
+    const breakEl = breakContainerRefs.current.get(activeBreakInfo.breakKey)
+    const scrollEl = scrollContainerRef.current
+    if (!breakEl || !scrollEl) return
+
+    programmaticScrollRef.current = true
+    breakEl.scrollIntoView({
+      behavior: isSafari ? 'auto' : 'smooth',
+      block: 'center',
+    })
+
+    const clearFlag = () => {
+      programmaticScrollRef.current = false
+    }
+
+    if ('onscrollend' in scrollEl) {
+      scrollEl.addEventListener('scrollend', clearFlag, { once: true })
+      return () => {
+        scrollEl.removeEventListener('scrollend', clearFlag)
+      }
+    }
+    const handle = setTimeout(clearFlag, 700)
+    return () => clearTimeout(handle)
+  }, [activeBreakInfo?.breakKey])
+
   // Defensive: should never be mounted without word timing, but bail out safely.
   if (!normalized.hasWordTiming) return null
 
@@ -156,11 +247,14 @@ export function WordLevelLyricsContainer({
       activeLineIdx={activeLineIdx}
       activeCueByKey={activeCueByKey}
       lastVisitedCueByKey={lastVisitedCueByKey}
+      activeBreakInfo={activeBreakInfo}
       onWordClick={onWordClick}
       resolvedLang={resolvedLang}
       scrollContainerRef={scrollContainerRef}
       lineRefs={lineRefs}
+      breakContainerRefs={breakContainerRefs}
       registerWordRef={registerWordRef}
+      registerDotRef={registerDotRef}
     />
   )
 }

--- a/src/app/components/fullscreen/word-level-lyrics/container.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/container.tsx
@@ -77,27 +77,32 @@ export function WordLevelLyricsContainer({
   } | null>(null)
 
   // Karaoke wipe progress channel. Fires every animation frame from
-  // useRafActiveCue. Writes `--fill` directly to the active cue's <span> DOM
+  // useRafActiveCue. Writes `--fill` directly to each active cue's <span> DOM
   // node — NOT via React state — so smooth 60fps fill costs zero re-renders.
+  // Iterates the entire cluster (activeLineIndices) so concurrent voices on
+  // different line indices each get their own karaoke wipe simultaneously.
   // Only the active cue(s) get a write; past/future cues lack the
   // `.karaoke-fill` class so their `--fill` value is inert.
   const handleTick = useCallback(
-    ({ t, activeLineIdx: lineIdx, activeCueByKey: cueByKey }: RafTickInfo) => {
-      if (lineIdx >= 0) {
+    ({
+      t,
+      activeLineIndices: lineIndices,
+      activeCueByKey: cueByKey,
+    }: RafTickInfo) => {
+      for (const lineIdx of lineIndices) {
         const line = normalized.lines[lineIdx]
-        if (line) {
-          for (const cueLine of line.cueLines) {
-            const cueIdx = cueByKey[cueLine.key]
-            if (cueIdx == null || cueIdx < 0) continue
-            const cue = cueLine.cues[cueIdx]
-            if (!cue) continue
-            const duration = Math.max(1, cue.end - cue.start)
-            const pct = Math.max(0, Math.min(1, (t - cue.start) / duration))
-            const el = wordRefs.current.get(
-              `${lineIdx}|${cueLine.key}|${cueIdx}`,
-            )
-            if (el) el.style.setProperty('--fill', `${pct * 100}%`)
-          }
+        if (!line) continue
+        for (const cueLine of line.cueLines) {
+          const cueIdx = cueByKey[cueLine.key]
+          if (cueIdx == null || cueIdx < 0) continue
+          const cue = cueLine.cues[cueIdx]
+          if (!cue) continue
+          const duration = Math.max(1, cue.end - cue.start)
+          const pct = Math.max(0, Math.min(1, (t - cue.start) / duration))
+          const el = wordRefs.current.get(
+            `${lineIdx}|${cueLine.key}|${cueIdx}`,
+          )
+          if (el) el.style.setProperty('--fill', `${pct * 100}%`)
         }
       }
 
@@ -134,13 +139,22 @@ export function WordLevelLyricsContainer({
   )
 
   // 60fps active-index tracking + karaoke wipe tick.
-  const { activeLineIdx, activeCueByKey, lastVisitedCueByKey } =
-    useRafActiveCue({
-      lines: normalized.lines,
-      getCurrentTimeMs,
-      enabled: enabled && normalized.hasWordTiming,
-      onTick: handleTick,
-    })
+  const {
+    activeLineIdx,
+    activeLineIndices,
+    activeCueByKey,
+    lastVisitedCueByKey,
+  } = useRafActiveCue({
+    lines: normalized.lines,
+    getCurrentTimeMs,
+    enabled: enabled && normalized.hasWordTiming,
+    onTick: handleTick,
+  })
+
+  // Cluster anchor (earliest currently-active line index). The scroll effect
+  // keys off this value so joiners arriving mid-cluster do NOT re-fire scroll;
+  // the first line of the cluster stays anchored per the concurrent-voice spec.
+  const scrollAnchorIdx = activeLineIndices[0] ?? -1
 
   const onWordClick = useWordSeek()
 
@@ -167,13 +181,14 @@ export function WordLevelLyricsContainer({
     return () => el.removeEventListener('scroll', onScroll)
   }, [])
 
-  // Scroll active line into view when it changes. Fires once per activeLineIdx
-  // change — never per rAF tick — because the effect depends on activeLineIdx.
+  // Scroll cluster anchor (first active line) into view when the anchor
+  // changes. Fires once per anchor change — never per rAF tick, never on
+  // mid-cluster joiners — because the effect depends only on scrollAnchorIdx.
   useEffect(() => {
-    if (activeLineIdx < 0) return
+    if (scrollAnchorIdx < 0) return
     if (performance.now() < userScrollGuardRef.current.pausedUntilMs) return
 
-    const lineEl = lineRefs.current[activeLineIdx]
+    const lineEl = lineRefs.current[scrollAnchorIdx]
     const scrollEl = scrollContainerRef.current
     if (!lineEl || !scrollEl) return
 
@@ -203,7 +218,7 @@ export function WordLevelLyricsContainer({
     }
     const handle = setTimeout(clearFlag, 700)
     return () => clearTimeout(handle)
-  }, [activeLineIdx])
+  }, [scrollAnchorIdx])
 
   // Mirror of the line scroll effect for instrumental breaks. Keyed only on
   // breakKey (not dotIdx) so we scroll on break entry, not every ~1s dot
@@ -245,6 +260,7 @@ export function WordLevelLyricsContainer({
     <WordLevelLyricsView
       data={normalized}
       activeLineIdx={activeLineIdx}
+      activeLineIndices={activeLineIndices}
       activeCueByKey={activeCueByKey}
       lastVisitedCueByKey={lastVisitedCueByKey}
       activeBreakInfo={activeBreakInfo}

--- a/src/app/components/fullscreen/word-level-lyrics/container.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/container.tsx
@@ -11,6 +11,47 @@ import { WordLevelLyricsView } from './view'
 
 const SCROLL_RECOVERY_MS = 1500
 
+function useScrollToElementWithRecovery(
+  trigger: unknown,
+  scrollContainerRef: React.RefObject<HTMLDivElement>,
+  programmaticScrollRef: React.MutableRefObject<boolean>,
+  userScrollGuardRef: React.MutableRefObject<{ pausedUntilMs: number }>,
+  resolveTarget: () => HTMLElement | null,
+) {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: trigger is the explicit driver; resolveTarget reads stable refs
+  useEffect(() => {
+    if (trigger == null) return
+    if (performance.now() < userScrollGuardRef.current.pausedUntilMs) return
+
+    const targetEl = resolveTarget()
+    const scrollEl = scrollContainerRef.current
+    if (!targetEl || !scrollEl) return
+
+    programmaticScrollRef.current = true
+    targetEl.scrollIntoView({
+      behavior: isSafari ? 'auto' : 'smooth',
+      block: 'center',
+    })
+
+    const clearFlag = () => {
+      programmaticScrollRef.current = false
+    }
+
+    // Smooth scrollIntoView dispatches async `scroll` events for ~300-500ms;
+    // hold the programmatic flag until the real end, otherwise the scroll
+    // listener treats them as a user scroll and pauses auto-scroll. Prefer
+    // `scrollend` over a timer.
+    if ('onscrollend' in scrollEl) {
+      scrollEl.addEventListener('scrollend', clearFlag, { once: true })
+      return () => {
+        scrollEl.removeEventListener('scrollend', clearFlag)
+      }
+    }
+    const handle = setTimeout(clearFlag, 700)
+    return () => clearTimeout(handle)
+  }, [trigger])
+}
+
 export interface WordLevelLyricsContainerProps {
   structuredLyric: IStructuredLyric
   /** When false, disables rAF polling (e.g. component not visible). Defaults to true. */
@@ -99,9 +140,7 @@ export function WordLevelLyricsContainer({
           if (!cue) continue
           const duration = Math.max(1, cue.end - cue.start)
           const pct = Math.max(0, Math.min(1, (t - cue.start) / duration))
-          const el = wordRefs.current.get(
-            `${lineIdx}|${cueLine.key}|${cueIdx}`,
-          )
+          const el = wordRefs.current.get(`${lineIdx}|${cueLine.key}|${cueIdx}`)
           if (el) el.style.setProperty('--fill', `${pct * 100}%`)
         }
       }
@@ -181,77 +220,30 @@ export function WordLevelLyricsContainer({
     return () => el.removeEventListener('scroll', onScroll)
   }, [])
 
-  // Scroll cluster anchor (first active line) into view when the anchor
-  // changes. Fires once per anchor change — never per rAF tick, never on
-  // mid-cluster joiners — because the effect depends only on scrollAnchorIdx.
-  useEffect(() => {
-    if (scrollAnchorIdx < 0) return
-    if (performance.now() < userScrollGuardRef.current.pausedUntilMs) return
+  // Scroll cluster anchor (first active line) into view when it changes.
+  // Joiners arriving mid-cluster don't re-fire scroll because the trigger is
+  // scrollAnchorIdx alone.
+  useScrollToElementWithRecovery(
+    scrollAnchorIdx >= 0 ? scrollAnchorIdx : null,
+    scrollContainerRef,
+    programmaticScrollRef,
+    userScrollGuardRef,
+    () => lineRefs.current[scrollAnchorIdx] ?? null,
+  )
 
-    const lineEl = lineRefs.current[scrollAnchorIdx]
-    const scrollEl = scrollContainerRef.current
-    if (!lineEl || !scrollEl) return
-
-    programmaticScrollRef.current = true
-    lineEl.scrollIntoView({
-      behavior: isSafari ? 'auto' : 'smooth',
-      block: 'center',
-    })
-
-    // A smooth scroll fires many `scroll` events asynchronously over ~300-500ms.
-    // We must keep `programmaticScrollRef.current` true until the scroll really
-    // finishes, otherwise the scroll-listener mistakes those events for a user
-    // scroll and pauses auto-scroll for SCROLL_RECOVERY_MS — causing the next
-    // line transition to be silently skipped.
-    const clearFlag = () => {
-      programmaticScrollRef.current = false
-    }
-
-    // Prefer the native `scrollend` event when available
-    // Otherwise fall back to a timeout long enough to
-    // cover typical smooth-scroll durations across browsers.
-    if ('onscrollend' in scrollEl) {
-      scrollEl.addEventListener('scrollend', clearFlag, { once: true })
-      return () => {
-        scrollEl.removeEventListener('scrollend', clearFlag)
-      }
-    }
-    const handle = setTimeout(clearFlag, 700)
-    return () => clearTimeout(handle)
-  }, [scrollAnchorIdx])
-
-  // Mirror of the line scroll effect for instrumental breaks. Keyed only on
-  // breakKey (not dotIdx) so we scroll on break entry, not every ~1s dot
-  // transition. When activeBreakInfo flips to null at break end, the next
-  // line's scroll effect picks up naturally.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on break entry only, not per-dot
-  useEffect(() => {
-    if (!activeBreakInfo) return
-    if (performance.now() < userScrollGuardRef.current.pausedUntilMs) return
-
-    const breakEl = breakContainerRefs.current.get(activeBreakInfo.breakKey)
-    const scrollEl = scrollContainerRef.current
-    if (!breakEl || !scrollEl) return
-
-    programmaticScrollRef.current = true
-    breakEl.scrollIntoView({
-      behavior: isSafari ? 'auto' : 'smooth',
-      block: 'center',
-    })
-
-    const clearFlag = () => {
-      programmaticScrollRef.current = false
-    }
-
-    if ('onscrollend' in scrollEl) {
-      scrollEl.addEventListener('scrollend', clearFlag, { once: true })
-      return () => {
-        scrollEl.removeEventListener('scrollend', clearFlag)
-      }
-    }
-    const handle = setTimeout(clearFlag, 700)
-    return () => clearTimeout(handle)
-  }, [activeBreakInfo?.breakKey])
+  // Scroll on break entry only — keyed on breakKey, not dotIdx, so we don't
+  // re-scroll on every ~1s dot transition. When activeBreakInfo flips to null
+  // at break end, the next line's scroll picks up naturally.
+  useScrollToElementWithRecovery(
+    activeBreakInfo?.breakKey ?? null,
+    scrollContainerRef,
+    programmaticScrollRef,
+    userScrollGuardRef,
+    () =>
+      activeBreakInfo
+        ? (breakContainerRefs.current.get(activeBreakInfo.breakKey) ?? null)
+        : null,
+  )
 
   // Defensive: should never be mounted without word timing, but bail out safely.
   if (!normalized.hasWordTiming) return null

--- a/src/app/components/fullscreen/word-level-lyrics/index.ts
+++ b/src/app/components/fullscreen/word-level-lyrics/index.ts
@@ -1,0 +1,4 @@
+export type { WordLevelLyricsContainerProps } from './container'
+export { WordLevelLyricsContainer } from './container'
+export type { WordLevelLyricsViewProps } from './view'
+export { WordLevelLyricsView } from './view'

--- a/src/app/components/fullscreen/word-level-lyrics/view.cy.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.cy.tsx
@@ -1,0 +1,480 @@
+import {
+  normalizeStructuredLyric,
+  type NormalizedStructuredLyric,
+} from '@/utils/wordTiming'
+import { WordLevelLyricsView } from './view'
+
+/**
+ * Load raw fixture, pick the primary structuredLyric, normalise it,
+ * and hand the result to the test callback.
+ */
+function loadAndNormalize(
+  fixtureName: string,
+  callback: (n: NormalizedStructuredLyric) => void,
+) {
+  cy.fixture(`lyrics/${fixtureName}`).then((fx) => {
+    const rawList = fx['subsonic-response'].lyricsList.structuredLyrics
+    const raw =
+      rawList.find((l: { kind?: string }) => l.kind === 'main') ?? rawList[0]
+    callback(normalizeStructuredLyric(raw))
+  })
+}
+
+describe('WordLevelLyricsView Component', () => {
+  // 1
+  it('renders all lines from data.lines', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      // [data-active] is present ONLY on the line container divs; cueLine <p>
+      // children share the "word-line-" prefix but do not carry data-active.
+      cy.get('[data-testid^="word-line-"][data-active]').should(
+        'have.length',
+        data.lines.length,
+      )
+    })
+  })
+
+  // 2
+  it('active line container has opacity-100, others have opacity-50', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-line-1"]').should('have.class', 'opacity-100')
+      cy.get('[data-testid="word-line-0"]').should('have.class', 'opacity-50')
+    })
+  })
+
+  // 3
+  it('active word has text-primary AND font-semibold', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={0}
+          activeCueByKey={{ '0:pos0': 2 }}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-0-0:pos0-2"]')
+        .should('have.class', 'text-primary')
+        .and('have.class', 'font-semibold')
+    })
+  })
+
+  // 4
+  it('past words on active line have opacity-50', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={0}
+          activeCueByKey={{ '0:pos0': 2 }}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-0-0:pos0-0"]').should(
+        'have.class',
+        'opacity-50',
+      )
+      cy.get('[data-testid="word-0-0:pos0-1"]').should(
+        'have.class',
+        'opacity-50',
+      )
+    })
+  })
+
+  // 5
+  it('future words on active line have neither opacity-50 nor text-primary', () => {
+    // NOTE: line 0 of v2-with-cues only has 3 cues (indices 0..2). To get a
+    // FUTURE cue on the active line we set the active cue to 0 — then cue 2
+    // ("through") is in the future state and serves as the assertion target.
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={0}
+          activeCueByKey={{ '0:pos0': 0 }}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-0-0:pos0-2"]')
+        .should('not.have.class', 'text-primary')
+        .and('not.have.class', 'opacity-50')
+    })
+  })
+
+  // 6
+  it('CJK byte-aware rendering', () => {
+    loadAndNormalize('v2-cjk-korean.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={0}
+          activeCueByKey={{ '0:pos0': 0 }}
+          onWordClick={cy.stub()}
+          resolvedLang="ko"
+        />,
+      )
+      // First cue is the Hangul syllable "눈" (UTF-8 bytes 0..2 of "눈을 뜬 순간").
+      cy.get('[data-testid="word-0-0:pos0-0"]').should(
+        'have.attr',
+        'data-text',
+        '눈',
+      )
+    })
+  })
+
+  // 7
+  it('whitespace-only cue has aria-hidden="true"', () => {
+    loadAndNormalize('v2-cjk-korean.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={0}
+          activeCueByKey={{ '0:pos0': 0 }}
+          onWordClick={cy.stub()}
+          resolvedLang="ko"
+        />,
+      )
+      // Cue 2 is the inter-syllable space (byteStart === byteEnd === 6).
+      cy.get('[data-testid="word-0-0:pos0-2"]').should(
+        'have.attr',
+        'aria-hidden',
+        'true',
+      )
+    })
+  })
+
+  // 8
+  it('click on word invokes onWordClick spy with cue.start', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      const onWordClick = cy.stub().as('onWordClick')
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={onWordClick}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-0-0:pos0-0"]').click()
+      // cue 0 of line 0 in v2-with-cues starts at 1000 ms (offset=0).
+      cy.get('@onWordClick').should('have.been.calledWith', 1000)
+    })
+  })
+
+  // 9
+  it('keyboard Enter invokes onWordClick', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      const onWordClick = cy.stub().as('onWordClick')
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={onWordClick}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-0-0:pos0-0"]')
+        .focus()
+        .trigger('keydown', { key: 'Enter' })
+      cy.get('@onWordClick').should('have.been.called')
+    })
+  })
+
+  // 10
+  it('keyboard Space invokes onWordClick AND prevents default scroll', () => {
+    // The handler calls e.preventDefault() before invoking the spy, so the
+    // spy assertion proves the handler ran to completion (and thus that
+    // preventDefault was executed — the page-scroll guard is the same code
+    // path).
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      const onWordClick = cy.stub().as('onWordClick')
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={onWordClick}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-0-0:pos0-0"]')
+        .focus()
+        .trigger('keydown', { key: ' ' })
+      cy.get('@onWordClick').should('have.been.called')
+    })
+  })
+
+  // 11
+  it('width-reservation sibling span present on non-whitespace cues', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-0-0:pos0-0"] > span[aria-hidden="true"]')
+        .should('exist')
+        .and('have.class', 'font-semibold')
+    })
+  })
+
+  // 12
+  it('lang attribute on cueLine sub-rows', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="ko"
+        />,
+      )
+      cy.get('[data-testid^="word-line-0-cueline-"]').should(
+        'have.attr',
+        'lang',
+        'ko',
+      )
+    })
+  })
+
+  // 13
+  it('dir="auto" on cueLine sub-rows', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid^="word-line-0-cueline-"]').should(
+        'have.attr',
+        'dir',
+        'auto',
+      )
+    })
+  })
+
+  // 14
+  it('Safari user-agent — no scroll-smooth on scroll container', () => {
+    // LIMITATION: isSafari from react-device-detect is evaluated at
+    // module-load time, so stubbing window.navigator.userAgent from inside a
+    // running test cannot flip the branch. Cypress component tests run in a
+    // Chromium-based browser by default, so isSafari === false here and
+    // 'scroll-smooth' IS present. We assert the non-Safari path; the inverse
+    // (Safari → no scroll-smooth) is covered by inspection of view.tsx.
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-sync-lyrics-box"]').should(
+        'have.class',
+        'scroll-smooth',
+      )
+    })
+  })
+
+  // 15
+  it('scroll container has data-testid="word-sync-lyrics-box"', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-sync-lyrics-box"]').should('exist')
+    })
+  })
+
+  // 16
+  it('line without cueLine renders plain line.value without cue spans', () => {
+    loadAndNormalize('v2-no-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      data.lines.forEach((line, i) => {
+        cy.get(`[data-testid="word-line-${i}"]`)
+          .find('p')
+          .should('contain.text', line.value)
+        // No cue spans inside this line: cue testids are word-${i}-..., which
+        // does NOT overlap with word-line-${i}- (line/cueLine testids).
+        cy.get(
+          `[data-testid="word-line-${i}"] [data-testid^="word-${i}-"]`,
+        ).should('not.exist')
+      })
+    })
+  })
+
+  // 17
+  it('transition class includes motion-reduce:transition-none on cue spans', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-0-0:pos0-0"]').should(
+        'have.class',
+        'motion-reduce:transition-none',
+      )
+    })
+  })
+
+  // 18
+  it('multi-agent: two sub-rows render per line', () => {
+    loadAndNormalize('v2-multi-agent-different-value.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-line-0"] > p').should('have.length', 2)
+
+      cy.get('[data-testid="word-line-0"] > p[data-display-order="0"]')
+        .should('exist')
+        .and('not.have.class', 'opacity-70')
+
+      cy.get('[data-testid="word-line-0"] > p[data-display-order="1"]')
+        .should('exist')
+        .and('have.class', 'opacity-70')
+        .and('have.class', 'text-sm')
+    })
+  })
+
+  // 19
+  it('multi-agent: agentRole exposed via data-agent-role attribute', () => {
+    loadAndNormalize('v2-multi-agent-different-value.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('p[data-agent-role="main"]').should('exist')
+      cy.get('p[data-agent-role="bg"]').should('exist')
+    })
+  })
+
+  // 20
+  it('multi-agent: independent active highlighting per agent sub-row', () => {
+    loadAndNormalize('v2-multi-agent-different-value.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={0}
+          activeCueByKey={{ '0:lead': 0, '0:bg': 0 }}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-0-0:lead-0"]').should(
+        'have.class',
+        'text-primary',
+      )
+      cy.get('[data-testid="word-0-0:bg-0"]').should(
+        'have.class',
+        'text-primary',
+      )
+    })
+  })
+
+  // 21
+  it('single-agent regression: exactly one sub-row, no opacity-70/text-sm', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-line-0"] > p').should('have.length', 1)
+      cy.get('[data-testid="word-line-0"] > p')
+        .should('not.have.class', 'opacity-70')
+        .and('not.have.class', 'text-sm')
+    })
+  })
+
+  // 22
+  it('data-active attribute on line container matches activeLineIdx', () => {
+    loadAndNormalize('v2-with-cues.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={1}
+          activeCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-line-1"]').should(
+        'have.attr',
+        'data-active',
+        'true',
+      )
+      cy.get('[data-testid="word-line-0"]').should(
+        'have.attr',
+        'data-active',
+        'false',
+      )
+    })
+  })
+})

--- a/src/app/components/fullscreen/word-level-lyrics/view.cy.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.cy.tsx
@@ -477,4 +477,146 @@ describe('WordLevelLyricsView Component', () => {
       )
     })
   })
+
+  // 23
+  it('cluster: cross-index concurrent lines all flip data-active=true simultaneously when activeLineIndices is multi-element', () => {
+    loadAndNormalize('v2-multi-agent-overlapping-indices.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={2}
+          activeLineIndices={[0, 1, 2]}
+          activeCueByKey={{}}
+          lastVisitedCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-line-0"]').should(
+        'have.attr',
+        'data-active',
+        'true',
+      )
+      cy.get('[data-testid="word-line-1"]').should(
+        'have.attr',
+        'data-active',
+        'true',
+      )
+      cy.get('[data-testid="word-line-2"]').should(
+        'have.attr',
+        'data-active',
+        'true',
+      )
+    })
+  })
+
+  // 24
+  it('cluster: scale-125 applies to every line in activeLineIndices', () => {
+    loadAndNormalize('v2-multi-agent-overlapping-indices.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={2}
+          activeLineIndices={[0, 1, 2]}
+          activeCueByKey={{}}
+          lastVisitedCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-line-0"]').should('have.class', 'scale-125')
+      cy.get('[data-testid="word-line-1"]').should('have.class', 'scale-125')
+      cy.get('[data-testid="word-line-2"]').should('have.class', 'scale-125')
+    })
+  })
+
+  // 25
+  it('cluster: each active line carries its own karaoke-fill cue (per-line independent highlighting)', () => {
+    loadAndNormalize('v2-multi-agent-overlapping-indices.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={2}
+          activeLineIndices={[0, 1, 2]}
+          activeCueByKey={{
+            '0:lead': 2,
+            '1:echo': 0,
+            '2:choir': 0,
+          }}
+          lastVisitedCueByKey={{
+            '0:lead': 2,
+            '1:echo': 0,
+            '2:choir': 0,
+          }}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-0-0:lead-2"]').should(
+        'have.class',
+        'karaoke-fill',
+      )
+      cy.get('[data-testid="word-1-1:echo-0"]').should(
+        'have.class',
+        'karaoke-fill',
+      )
+      cy.get('[data-testid="word-2-2:choir-0"]').should(
+        'have.class',
+        'karaoke-fill',
+      )
+    })
+  })
+
+  // 26
+  it('cluster back-compat: activeLineIndices omitted falls back to [activeLineIdx] (existing single-index tests keep working)', () => {
+    loadAndNormalize('v2-multi-agent-overlapping-indices.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={1}
+          activeCueByKey={{}}
+          lastVisitedCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-line-1"]').should(
+        'have.attr',
+        'data-active',
+        'true',
+      )
+      cy.get('[data-testid="word-line-0"]').should(
+        'have.attr',
+        'data-active',
+        'false',
+      )
+      cy.get('[data-testid="word-line-2"]').should(
+        'have.attr',
+        'data-active',
+        'false',
+      )
+    })
+  })
+
+  // 27
+  it('cluster: line OUTSIDE the cluster but before its anchor renders cues as past (i < activeLineIdx fallback)', () => {
+    loadAndNormalize('v2-multi-agent-overlapping-indices.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={2}
+          activeLineIndices={[1, 2]}
+          activeCueByKey={{ '1:echo': 0, '2:choir': 0 }}
+          lastVisitedCueByKey={{ '1:echo': 0, '2:choir': 0 }}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-0-0:lead-0"]').should(
+        'have.attr',
+        'data-state',
+        'past',
+      )
+    })
+  })
 })

--- a/src/app/components/fullscreen/word-level-lyrics/view.cy.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.cy.tsx
@@ -619,4 +619,46 @@ describe('WordLevelLyricsView Component', () => {
       )
     })
   })
+
+  // 28
+  it('cluster: rightmost-started line that has ENDED while an earlier concurrent line keeps going renders past, not future (regression for i === activeLineIdx outside set)', () => {
+    // Simulates: Line 0 still active, Line 1 ended (its end < t < Line 2's start).
+    // Hook would emit activeLineIdx=1, activeLineIndices=[0]. The strict `<`
+    // boundary regressed before; this test guards the `<=` fix.
+    loadAndNormalize('v2-multi-agent-overlapping-indices.json', (data) => {
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={1}
+          activeLineIndices={[0]}
+          activeCueByKey={{ '0:lead': 2 }}
+          lastVisitedCueByKey={{
+            '0:lead': 2,
+            '1:echo': 2,
+          }}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-1-1:echo-0"]').should(
+        'have.attr',
+        'data-state',
+        'past',
+      )
+      cy.get('[data-testid="word-1-1:echo-2"]').should(
+        'have.attr',
+        'data-state',
+        'past',
+      )
+      cy.get('[data-testid="word-1-1:echo-0"]').should(
+        'have.class',
+        'opacity-50',
+      )
+      cy.get('[data-testid="word-2-2:choir-0"]').should(
+        'have.attr',
+        'data-state',
+        'future',
+      )
+    })
+  })
 })

--- a/src/app/components/fullscreen/word-level-lyrics/view.cy.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.cy.tsx
@@ -661,4 +661,53 @@ describe('WordLevelLyricsView Component', () => {
       )
     })
   })
+
+  // 29
+  it('empty-text line is hidden when a break covers its time slot', () => {
+    // Fixture: line 0 ends at 2000, empty line at 2000, next real line at 7000
+    // (5s gap). A break with [start=2000, end=7000] is generated; the empty
+    // line falls inside it and should NOT render.
+    loadAndNormalize('v2-with-empty-lines.json', (data) => {
+      expect(data.breaks.length, 'one break detected').to.equal(1)
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          lastVisitedCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-line-0"]').should('exist')
+      cy.get('[data-testid="word-line-1"]').should('not.exist')
+      cy.get('[data-testid="word-line-2"]').should('exist')
+      cy.get('[data-testid="instrumental-break-brk:2"]').should('exist')
+    })
+  })
+
+  // 30
+  it('empty-text line stays visible when the gap is sub-threshold (no break to replace it)', () => {
+    // Fixture: line 0 ends at 2000, empty line at 2000, next real line at 4000
+    // (2s gap, below the 3s break threshold). No break is generated, so the
+    // empty line must remain visible as the only "clear display" signal.
+    loadAndNormalize('v2-empty-line-short-gap.json', (data) => {
+      expect(data.breaks.length, 'no break generated').to.equal(0)
+      cy.mount(
+        <WordLevelLyricsView
+          data={data}
+          activeLineIdx={-1}
+          activeCueByKey={{}}
+          lastVisitedCueByKey={{}}
+          onWordClick={cy.stub()}
+          resolvedLang="en"
+        />,
+      )
+      cy.get('[data-testid="word-line-0"]').should('exist')
+      cy.get('[data-testid="word-line-1"]').should('exist')
+      cy.get('[data-testid="word-line-1"]').find('p').should('have.text', '')
+      cy.get('[data-testid="word-line-2"]').should('exist')
+      cy.get('[data-testid^="instrumental-break-"]').should('not.exist')
+    })
+  })
 })

--- a/src/app/components/fullscreen/word-level-lyrics/view.cy.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.cy.tsx
@@ -60,7 +60,7 @@ describe('WordLevelLyricsView Component', () => {
   })
 
   // 3
-  it('active word has text-primary AND font-semibold', () => {
+  it('active word has karaoke-fill AND font-semibold', () => {
     loadAndNormalize('v2-with-cues.json', (data) => {
       cy.mount(
         <WordLevelLyricsView
@@ -72,7 +72,7 @@ describe('WordLevelLyricsView Component', () => {
         />,
       )
       cy.get('[data-testid="word-0-0:pos0-2"]')
-        .should('have.class', 'text-primary')
+        .should('have.class', 'karaoke-fill')
         .and('have.class', 'font-semibold')
     })
   })
@@ -101,7 +101,7 @@ describe('WordLevelLyricsView Component', () => {
   })
 
   // 5
-  it('future words on active line have neither opacity-50 nor text-primary', () => {
+  it('future words on active line have neither opacity-50 nor karaoke-fill', () => {
     // NOTE: line 0 of v2-with-cues only has 3 cues (indices 0..2). To get a
     // FUTURE cue on the active line we set the active cue to 0 — then cue 2
     // ("through") is in the future state and serves as the assertion target.
@@ -116,7 +116,7 @@ describe('WordLevelLyricsView Component', () => {
         />,
       )
       cy.get('[data-testid="word-0-0:pos0-2"]')
-        .should('not.have.class', 'text-primary')
+        .should('not.have.class', 'karaoke-fill')
         .and('not.have.class', 'opacity-50')
     })
   })
@@ -425,11 +425,11 @@ describe('WordLevelLyricsView Component', () => {
       )
       cy.get('[data-testid="word-0-0:lead-0"]').should(
         'have.class',
-        'text-primary',
+        'karaoke-fill',
       )
       cy.get('[data-testid="word-0-0:bg-0"]').should(
         'have.class',
-        'text-primary',
+        'karaoke-fill',
       )
     })
   })

--- a/src/app/components/fullscreen/word-level-lyrics/view.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.tsx
@@ -168,7 +168,8 @@ export function WordLevelLyricsView({
                           } else {
                             cueState = 'future'
                           }
-                        } else if (i < activeLineIdx) {
+                        } else if (i <= activeLineIdx) {
+                          // `<=`, not `<`: catches the rightmost-started line when it has ended while an earlier concurrent line keeps going (i === activeLineIdx AND not in active set).
                           cueState = 'past'
                         } else {
                           cueState = 'future'

--- a/src/app/components/fullscreen/word-level-lyrics/view.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.tsx
@@ -80,6 +80,29 @@ export function WordLevelLyricsView({
     return activeLineIdx >= 0 ? new Set([activeLineIdx]) : new Set<number>()
   }, [activeLineIndices, activeLineIdx])
 
+  // Empty-text "clear marker" lines are hidden ONLY when a break replaces
+  // them — otherwise they stay visible. Sub-threshold (<3s) gaps emit no
+  // break, so the blank line remains as the only "lyrics ended" signal.
+  // Trailing tombstones likewise stay visible (computeBreaks emits no
+  // outro break).
+  const hiddenLineIndices = useMemo<ReadonlySet<number>>(() => {
+    if (data.breaks.length === 0) return new Set<number>()
+    const hidden = new Set<number>()
+    for (let i = 0; i < data.lines.length; i++) {
+      const line = data.lines[i]
+      if (line.cueLines.length > 0) continue
+      if (line.value !== '') continue
+      if (line.start == null) continue
+      for (const brk of data.breaks) {
+        if (line.start >= brk.start && line.start < brk.end) {
+          hidden.add(i)
+          break
+        }
+      }
+    }
+    return hidden
+  }, [data.breaks, data.lines])
+
   return (
     <div
       ref={scrollContainerRef}
@@ -93,6 +116,7 @@ export function WordLevelLyricsView({
       <div aria-hidden="true" style={{ height: '50%' }} />
       {data.lines.map((line, i) => {
         const precedingBreak = breaksByLine.get(i)
+        const isHidden = hiddenLineIndices.has(i)
         return (
           <Fragment key={i}>
             {precedingBreak && (
@@ -110,116 +134,120 @@ export function WordLevelLyricsView({
                 }}
               />
             )}
-            <div
-              ref={(el) => {
-                if (lineRefs?.current) lineRefs.current[i] = el
-              }}
-              data-testid={`word-line-${i}`}
-              data-active={activeIndicesSet.has(i) ? 'true' : 'false'}
-              className={clsx(
-                'drop-shadow-lg my-5 duration-500 w-fit m-auto max-w-[80%] text-balance',
-                'transition-[transform] motion-reduce:transition-none',
-                activeIndicesSet.has(i) && !isBreakActive && 'scale-125',
-              )}
-            >
-              {line.cueLines.length === 0 ? (
-                <p lang={resolvedLang}>{line.value}</p>
-              ) : (
-                line.cueLines.map((cueLine) => {
-                  const activeCueIdxForThisCueLine =
-                    activeCueByKey[cueLine.key] ?? -1
-                  const lastVisitedCueIdxForThisCueLine =
-                    lastVisitedCueByKey[cueLine.key] ?? -1
-                  return (
-                    <p
-                      key={cueLine.key}
-                      lang={resolvedLang}
-                      dir="auto"
-                      data-testid={`word-line-${i}-cueline-${cueLine.key}`}
-                      data-agent-role={cueLine.agentRole ?? 'unknown'}
-                      data-display-order={cueLine.displayOrder}
-                    >
-                      {cueLine.cues.map((cue, cueIdx) => {
-                        const renderedText = byteSliceFallback(
-                          cue,
-                          cueLine.value,
-                        )
-                        const isWhitespaceOnly =
-                          renderedText.trim().length === 0
+            {!isHidden && (
+              <div
+                ref={(el) => {
+                  if (lineRefs?.current) lineRefs.current[i] = el
+                }}
+                data-testid={`word-line-${i}`}
+                data-active={activeIndicesSet.has(i) ? 'true' : 'false'}
+                className={clsx(
+                  'drop-shadow-lg my-5 duration-500 w-fit m-auto max-w-[80%] text-balance',
+                  'transition-[transform] motion-reduce:transition-none',
+                  activeIndicesSet.has(i) && !isBreakActive && 'scale-125',
+                )}
+              >
+                {line.cueLines.length === 0 ? (
+                  <p lang={resolvedLang}>{line.value}</p>
+                ) : (
+                  line.cueLines.map((cueLine) => {
+                    const activeCueIdxForThisCueLine =
+                      activeCueByKey[cueLine.key] ?? -1
+                    const lastVisitedCueIdxForThisCueLine =
+                      lastVisitedCueByKey[cueLine.key] ?? -1
+                    return (
+                      <p
+                        key={cueLine.key}
+                        lang={resolvedLang}
+                        dir="auto"
+                        data-testid={`word-line-${i}-cueline-${cueLine.key}`}
+                        data-agent-role={cueLine.agentRole ?? 'unknown'}
+                        data-display-order={cueLine.displayOrder}
+                      >
+                        {cueLine.cues.map((cue, cueIdx) => {
+                          const renderedText = byteSliceFallback(
+                            cue,
+                            cueLine.value,
+                          )
+                          const isWhitespaceOnly =
+                            renderedText.trim().length === 0
 
-                        let cueState: 'past' | 'active' | 'future'
-                        if (activeIndicesSet.has(i)) {
-                          if (cueIdx === activeCueIdxForThisCueLine) {
-                            cueState = 'active'
-                          } else if (
-                            cueIdx <= lastVisitedCueIdxForThisCueLine
-                          ) {
+                          let cueState: 'past' | 'active' | 'future'
+                          if (activeIndicesSet.has(i)) {
+                            if (cueIdx === activeCueIdxForThisCueLine) {
+                              cueState = 'active'
+                            } else if (
+                              cueIdx <= lastVisitedCueIdxForThisCueLine
+                            ) {
+                              cueState = 'past'
+                            } else {
+                              cueState = 'future'
+                            }
+                          } else if (i <= activeLineIdx) {
+                            // `<=`, not `<`: catches the rightmost-started line when it has ended while an earlier concurrent line keeps going (i === activeLineIdx AND not in active set).
                             cueState = 'past'
                           } else {
                             cueState = 'future'
                           }
-                        } else if (i <= activeLineIdx) {
-                          // `<=`, not `<`: catches the rightmost-started line when it has ended while an earlier concurrent line keeps going (i === activeLineIdx AND not in active set).
-                          cueState = 'past'
-                        } else {
-                          cueState = 'future'
-                        }
 
-                        const hueRotation =
-                          cueState === 'active' && cueLine.displayOrder >= 1
-                            ? SECONDARY_AGENT_HUE_ROTATIONS[
-                                (cueLine.displayOrder - 1) %
-                                  SECONDARY_AGENT_HUE_ROTATIONS.length
-                              ]
-                            : undefined
-                        const isDim =
-                          cueState === 'past' ||
-                          (cueState === 'future' && i > activeLineIdx)
-                        const cueClassName = clsx(
-                          !isWhitespaceOnly &&
-                            'cursor-pointer hover:opacity-100 [word-break:keep-all]',
-                          isDim && 'opacity-50',
-                          cueState === 'active' && 'font-semibold',
-                          cueState === 'active' &&
+                          const hueRotation =
+                            cueState === 'active' && cueLine.displayOrder >= 1
+                              ? SECONDARY_AGENT_HUE_ROTATIONS[
+                                  (cueLine.displayOrder - 1) %
+                                    SECONDARY_AGENT_HUE_ROTATIONS.length
+                                ]
+                              : undefined
+                          const isDim =
+                            cueState === 'past' ||
+                            (cueState === 'future' && i > activeLineIdx)
+                          const cueClassName = clsx(
                             !isWhitespaceOnly &&
-                            'karaoke-fill',
-                        )
-                        const wordKey = `${i}|${cueLine.key}|${cueIdx}`
+                              'cursor-pointer hover:opacity-100 [word-break:keep-all]',
+                            isDim && 'opacity-50',
+                            cueState === 'active' && 'font-semibold',
+                            cueState === 'active' &&
+                              !isWhitespaceOnly &&
+                              'karaoke-fill',
+                          )
+                          const wordKey = `${i}|${cueLine.key}|${cueIdx}`
 
-                        return (
-                          <span
-                            key={cueIdx}
-                            ref={(el) => registerWordRef?.(wordKey, el)}
-                            data-testid={`word-${i}-${cueLine.key}-${cueIdx}`}
-                            data-state={cueState}
-                            aria-hidden={isWhitespaceOnly ? 'true' : undefined}
-                            className={cueClassName}
-                            style={
-                              hueRotation !== undefined
-                                ? { filter: `hue-rotate(${hueRotation}deg)` }
-                                : undefined
-                            }
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              onWordClick(cue.start)
-                            }}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault()
-                                onWordClick(cue.start)
+                          return (
+                            <span
+                              key={cueIdx}
+                              ref={(el) => registerWordRef?.(wordKey, el)}
+                              data-testid={`word-${i}-${cueLine.key}-${cueIdx}`}
+                              data-state={cueState}
+                              aria-hidden={
+                                isWhitespaceOnly ? 'true' : undefined
                               }
-                            }}
-                            tabIndex={isWhitespaceOnly ? -1 : 0}
-                          >
-                            {renderedText}
-                          </span>
-                        )
-                      })}
-                    </p>
-                  )
-                })
-              )}
-            </div>
+                              className={cueClassName}
+                              style={
+                                hueRotation !== undefined
+                                  ? { filter: `hue-rotate(${hueRotation}deg)` }
+                                  : undefined
+                              }
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                onWordClick(cue.start)
+                              }}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault()
+                                  onWordClick(cue.start)
+                                }
+                              }}
+                              tabIndex={isWhitespaceOnly ? -1 : 0}
+                            >
+                              {renderedText}
+                            </span>
+                          )
+                        })}
+                      </p>
+                    )
+                  })
+                )}
+              </div>
+            )}
           </Fragment>
         )
       })}

--- a/src/app/components/fullscreen/word-level-lyrics/view.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.tsx
@@ -66,7 +66,7 @@ export function WordLevelLyricsView({
           data-testid={`word-line-${i}`}
           data-active={i === activeLineIdx ? 'true' : 'false'}
           className={clsx(
-            'drop-shadow-lg my-5 duration-500',
+            'drop-shadow-lg my-5 duration-500 w-fit m-auto max-w-[80%] text-balance',
             'transition-[transform] motion-reduce:transition-none',
             i === activeLineIdx && 'scale-125',
           )}
@@ -119,9 +119,9 @@ export function WordLevelLyricsView({
                       cueState === 'past' ||
                       (cueState === 'future' && i > activeLineIdx)
                     const cueClassName = clsx(
-                      'transition-[color,font-weight,opacity] duration-150 motion-reduce:transition-none',
+                      'transition-[color,font-weight,opacity,filter] duration-150 motion-reduce:transition-none',
                       !isWhitespaceOnly &&
-                        'cursor-pointer whitespace-nowrap hover:opacity-100',
+                        'cursor-pointer hover:opacity-100 [word-break:keep-all]',
                       isDim && 'opacity-50',
                       cueState === 'active' && 'text-primary font-semibold',
                       hueClass,

--- a/src/app/components/fullscreen/word-level-lyrics/view.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.tsx
@@ -34,6 +34,13 @@ export interface WordLevelLyricsViewProps {
   scrollContainerRef?: React.Ref<HTMLDivElement>
   /** Refs for each LINE CONTAINER <div> by line index — for scroll-into-view. */
   lineRefs?: React.MutableRefObject<(HTMLDivElement | null)[]>
+  /**
+   * Called on mount with the cue <span> element and on unmount with null, keyed
+   * by `${lineIdx}|${cueLine.key}|${cueIdx}`. The container uses this to drive
+   * the karaoke `--fill` CSS variable directly on each span via rAF, bypassing
+   * React state updates so the smooth fill animation doesn't cost re-renders.
+   */
+  registerWordRef?: (key: string, el: HTMLSpanElement | null) => void
 }
 
 export function WordLevelLyricsView({
@@ -45,6 +52,7 @@ export function WordLevelLyricsView({
   resolvedLang,
   scrollContainerRef,
   lineRefs,
+  registerWordRef,
 }: WordLevelLyricsViewProps) {
   return (
     <div
@@ -122,13 +130,18 @@ export function WordLevelLyricsView({
                       !isWhitespaceOnly &&
                         'cursor-pointer hover:opacity-100 [word-break:keep-all]',
                       isDim && 'opacity-50',
-                      cueState === 'active' && 'text-primary font-semibold',
+                      cueState === 'active' && 'font-semibold',
+                      cueState === 'active' &&
+                        !isWhitespaceOnly &&
+                        'karaoke-fill',
                       hueClass,
                     )
+                    const wordKey = `${i}|${cueLine.key}|${cueIdx}`
 
                     return (
                       <span
                         key={cueIdx}
+                        ref={(el) => registerWordRef?.(wordKey, el)}
                         data-testid={`word-${i}-${cueLine.key}-${cueIdx}`}
                         data-state={cueState}
                         aria-hidden={isWhitespaceOnly ? 'true' : undefined}

--- a/src/app/components/fullscreen/word-level-lyrics/view.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.tsx
@@ -119,7 +119,6 @@ export function WordLevelLyricsView({
                       cueState === 'past' ||
                       (cueState === 'future' && i > activeLineIdx)
                     const cueClassName = clsx(
-                      'transition-[color,font-weight,opacity,filter] duration-150 motion-reduce:transition-none',
                       !isWhitespaceOnly &&
                         'cursor-pointer hover:opacity-100 [word-break:keep-all]',
                       isDim && 'opacity-50',

--- a/src/app/components/fullscreen/word-level-lyrics/view.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { Fragment } from 'react'
+import { Fragment, useMemo } from 'react'
 import { isSafari } from 'react-device-detect'
 import { byteSliceFallback } from '@/utils/byteSlice'
 import type {
@@ -19,9 +19,11 @@ const HUE_ROTATE_CLASSES = [
 
 export interface WordLevelLyricsViewProps {
   data: NormalizedStructuredLyric
-  /** -1 when no line is active. */
+  /** -1 when no line has started; else the rightmost-started line index (back-compat anchor for past/future boundary). */
   activeLineIdx: number
-  /** Map from NormalizedCueLine.key → active cue index. Empty Record when no line active. */
+  /** Asc-sorted indices of all currently-overlapping (cluster) lines. Optional; defaults to [activeLineIdx] when omitted, preserving single-line behaviour for existing callers. */
+  activeLineIndices?: ReadonlyArray<number>
+  /** Map from NormalizedCueLine.key → active cue index. Aggregated across every line in activeLineIndices. */
   activeCueByKey: Readonly<Record<string, number>>
   /**
    * Map from NormalizedCueLine.key → greatest cue index whose start time has
@@ -59,6 +61,7 @@ export interface WordLevelLyricsViewProps {
 export function WordLevelLyricsView({
   data,
   activeLineIdx,
+  activeLineIndices,
   activeCueByKey,
   lastVisitedCueByKey,
   activeBreakInfo = null,
@@ -75,6 +78,15 @@ export function WordLevelLyricsView({
     breaksByLine.set(brk.beforeLineIndex, brk)
   }
   const isBreakActive = activeBreakInfo !== null
+  // Cluster membership set: when activeLineIndices is provided and non-empty
+  // we use it directly; otherwise fall back to [activeLineIdx] so existing
+  // single-index callers (tests, single-track lyrics) keep working unchanged.
+  const activeIndicesSet = useMemo<ReadonlySet<number>>(() => {
+    if (activeLineIndices && activeLineIndices.length > 0) {
+      return new Set(activeLineIndices)
+    }
+    return activeLineIdx >= 0 ? new Set([activeLineIdx]) : new Set<number>()
+  }, [activeLineIndices, activeLineIdx])
 
   return (
     <div
@@ -111,11 +123,11 @@ export function WordLevelLyricsView({
                 if (lineRefs?.current) lineRefs.current[i] = el
               }}
               data-testid={`word-line-${i}`}
-              data-active={i === activeLineIdx ? 'true' : 'false'}
+              data-active={activeIndicesSet.has(i) ? 'true' : 'false'}
               className={clsx(
                 'drop-shadow-lg my-5 duration-500 w-fit m-auto max-w-[80%] text-balance',
                 'transition-[transform] motion-reduce:transition-none',
-                i === activeLineIdx && !isBreakActive && 'scale-125',
+                activeIndicesSet.has(i) && !isBreakActive && 'scale-125',
               )}
             >
               {line.cueLines.length === 0 ? (
@@ -146,9 +158,7 @@ export function WordLevelLyricsView({
                           renderedText.trim().length === 0
 
                         let cueState: 'past' | 'active' | 'future'
-                        if (i < activeLineIdx) {
-                          cueState = 'past'
-                        } else if (i === activeLineIdx) {
+                        if (activeIndicesSet.has(i)) {
                           if (cueIdx === activeCueIdxForThisCueLine) {
                             cueState = 'active'
                           } else if (
@@ -158,6 +168,8 @@ export function WordLevelLyricsView({
                           } else {
                             cueState = 'future'
                           }
+                        } else if (i < activeLineIdx) {
+                          cueState = 'past'
                         } else {
                           cueState = 'future'
                         }

--- a/src/app/components/fullscreen/word-level-lyrics/view.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.tsx
@@ -7,15 +7,7 @@ import type {
   NormalizedStructuredLyric,
 } from '@/utils/wordTiming'
 
-const HUE_ROTATE_CLASSES = [
-  '[filter:hue-rotate(180deg)]',
-  '[filter:hue-rotate(90deg)]',
-  '[filter:hue-rotate(270deg)]',
-  '[filter:hue-rotate(45deg)]',
-  '[filter:hue-rotate(135deg)]',
-  '[filter:hue-rotate(225deg)]',
-  '[filter:hue-rotate(315deg)]',
-] as const
+const SECONDARY_AGENT_HUE_ROTATIONS = [180, 90, 270, 45, 135, 225, 315] as const
 
 export interface WordLevelLyricsViewProps {
   data: NormalizedStructuredLyric
@@ -143,12 +135,10 @@ export function WordLevelLyricsView({
                       key={cueLine.key}
                       lang={resolvedLang}
                       dir="auto"
-                      role="text"
                       data-testid={`word-line-${i}-cueline-${cueLine.key}`}
                       data-agent-role={cueLine.agentRole ?? 'unknown'}
                       data-display-order={cueLine.displayOrder}
                     >
-                      {/* NOTE: screen-reader fragmentation is a known limitation; role="text" on p partially mitigates it */}
                       {cueLine.cues.map((cue, cueIdx) => {
                         const renderedText = byteSliceFallback(
                           cue,
@@ -175,11 +165,11 @@ export function WordLevelLyricsView({
                           cueState = 'future'
                         }
 
-                        const hueClass =
+                        const hueRotation =
                           cueState === 'active' && cueLine.displayOrder >= 1
-                            ? HUE_ROTATE_CLASSES[
+                            ? SECONDARY_AGENT_HUE_ROTATIONS[
                                 (cueLine.displayOrder - 1) %
-                                  HUE_ROTATE_CLASSES.length
+                                  SECONDARY_AGENT_HUE_ROTATIONS.length
                               ]
                             : undefined
                         const isDim =
@@ -193,7 +183,6 @@ export function WordLevelLyricsView({
                           cueState === 'active' &&
                             !isWhitespaceOnly &&
                             'karaoke-fill',
-                          hueClass,
                         )
                         const wordKey = `${i}|${cueLine.key}|${cueIdx}`
 
@@ -205,6 +194,11 @@ export function WordLevelLyricsView({
                             data-state={cueState}
                             aria-hidden={isWhitespaceOnly ? 'true' : undefined}
                             className={cueClassName}
+                            style={
+                              hueRotation !== undefined
+                                ? { filter: `hue-rotate(${hueRotation}deg)` }
+                                : undefined
+                            }
                             onClick={(e) => {
                               e.stopPropagation()
                               onWordClick(cue.start)

--- a/src/app/components/fullscreen/word-level-lyrics/view.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.tsx
@@ -1,0 +1,163 @@
+import clsx from 'clsx'
+import { isSafari } from 'react-device-detect'
+import { byteSliceFallback } from '@/utils/byteSlice'
+import type { NormalizedStructuredLyric } from '@/utils/wordTiming'
+
+const HUE_ROTATE_CLASSES = [
+  '[filter:hue-rotate(180deg)]',
+  '[filter:hue-rotate(90deg)]',
+  '[filter:hue-rotate(270deg)]',
+  '[filter:hue-rotate(45deg)]',
+  '[filter:hue-rotate(135deg)]',
+  '[filter:hue-rotate(225deg)]',
+  '[filter:hue-rotate(315deg)]',
+] as const
+
+export interface WordLevelLyricsViewProps {
+  data: NormalizedStructuredLyric
+  /** -1 when no line is active. */
+  activeLineIdx: number
+  /** Map from NormalizedCueLine.key → active cue index. Empty Record when no line active. */
+  activeCueByKey: Readonly<Record<string, number>>
+  /**
+   * Map from NormalizedCueLine.key → greatest cue index whose start time has
+   * passed. Stays populated during inter-cue gaps and between-line transitions
+   * so previously-visited words keep their `opacity-50` past styling instead
+   * of snapping back to the future state.
+   */
+  lastVisitedCueByKey: Readonly<Record<string, number>>
+  /** Called with the cue's normalised (offset-applied) start time in ms. */
+  onWordClick: (cueStartMs: number) => void
+  /** Result of resolveLyricsLang(data.lang, langCode) — computed by the container. */
+  resolvedLang: string | undefined
+  /** Forwarded to the outer scroll container so the container can attach a ref. */
+  scrollContainerRef?: React.Ref<HTMLDivElement>
+  /** Refs for each LINE CONTAINER <div> by line index — for scroll-into-view. */
+  lineRefs?: React.MutableRefObject<(HTMLDivElement | null)[]>
+}
+
+export function WordLevelLyricsView({
+  data,
+  activeLineIdx,
+  activeCueByKey,
+  lastVisitedCueByKey,
+  onWordClick,
+  resolvedLang,
+  scrollContainerRef,
+  lineRefs,
+}: WordLevelLyricsViewProps) {
+  return (
+    <div
+      ref={scrollContainerRef}
+      data-testid="word-sync-lyrics-box"
+      className={clsx(
+        'w-full h-full text-center font-semibold text-2xl 2xl:text-3xl px-2 overflow-y-auto',
+        !isSafari && 'scroll-smooth',
+        'lrc-box maskImage-big-player-lyrics',
+      )}
+    >
+      <div aria-hidden="true" style={{ height: '50%' }} />
+      {data.lines.map((line, i) => (
+        <div
+          ref={(el) => {
+            if (lineRefs?.current) lineRefs.current[i] = el
+          }}
+          key={i}
+          data-testid={`word-line-${i}`}
+          data-active={i === activeLineIdx ? 'true' : 'false'}
+          className={clsx(
+            'drop-shadow-lg my-5 duration-500',
+            'transition-[transform] motion-reduce:transition-none',
+            i === activeLineIdx && 'scale-125',
+          )}
+        >
+          {line.cueLines.length === 0 ? (
+            <p lang={resolvedLang}>{line.value}</p>
+          ) : (
+            line.cueLines.map((cueLine) => {
+              const activeCueIdxForThisCueLine =
+                activeCueByKey[cueLine.key] ?? -1
+              const lastVisitedCueIdxForThisCueLine =
+                lastVisitedCueByKey[cueLine.key] ?? -1
+              return (
+                <p
+                  key={cueLine.key}
+                  lang={resolvedLang}
+                  dir="auto"
+                  role="text"
+                  data-testid={`word-line-${i}-cueline-${cueLine.key}`}
+                  data-agent-role={cueLine.agentRole ?? 'unknown'}
+                  data-display-order={cueLine.displayOrder}
+                >
+                  {cueLine.cues.map((cue, cueIdx) => {
+                    const renderedText = byteSliceFallback(cue, cueLine.value)
+                    const isWhitespaceOnly = renderedText.trim().length === 0
+
+                    let cueState: 'past' | 'active' | 'future'
+                    if (i < activeLineIdx) {
+                      cueState = 'past'
+                    } else if (i === activeLineIdx) {
+                      if (cueIdx === activeCueIdxForThisCueLine) {
+                        cueState = 'active'
+                      } else if (cueIdx <= lastVisitedCueIdxForThisCueLine) {
+                        cueState = 'past'
+                      } else {
+                        cueState = 'future'
+                      }
+                    } else {
+                      cueState = 'future'
+                    }
+
+                    const hueClass =
+                      cueState === 'active' && cueLine.displayOrder >= 1
+                        ? HUE_ROTATE_CLASSES[
+                            (cueLine.displayOrder - 1) %
+                              HUE_ROTATE_CLASSES.length
+                          ]
+                        : undefined
+                    const isDim =
+                      cueState === 'past' ||
+                      (cueState === 'future' && i > activeLineIdx)
+                    const cueClassName = clsx(
+                      'transition-[color,font-weight,opacity] duration-150 motion-reduce:transition-none',
+                      !isWhitespaceOnly &&
+                        'cursor-pointer whitespace-nowrap hover:opacity-100',
+                      isDim && 'opacity-50',
+                      cueState === 'active' && 'text-primary font-semibold',
+                      hueClass,
+                    )
+
+                    return (
+                      <span
+                        key={cueIdx}
+                        data-testid={`word-${i}-${cueLine.key}-${cueIdx}`}
+                        data-state={cueState}
+                        aria-hidden={isWhitespaceOnly ? 'true' : undefined}
+                        className={cueClassName}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          onWordClick(cue.start)
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault()
+                            onWordClick(cue.start)
+                          }
+                        }}
+                        tabIndex={isWhitespaceOnly ? -1 : 0}
+                      >
+                        {renderedText}
+                      </span>
+                    )
+                  })}
+                </p>
+              )
+            })
+          )}
+        </div>
+      ))}
+      {/* Bottom spacer mirrors react-lrc's verticalSpace=true — lets the last line scroll to center */}
+      <div aria-hidden="true" style={{ height: '50%' }} />
+    </div>
+  )
+}

--- a/src/app/components/fullscreen/word-level-lyrics/view.tsx
+++ b/src/app/components/fullscreen/word-level-lyrics/view.tsx
@@ -1,7 +1,11 @@
 import clsx from 'clsx'
+import { Fragment } from 'react'
 import { isSafari } from 'react-device-detect'
 import { byteSliceFallback } from '@/utils/byteSlice'
-import type { NormalizedStructuredLyric } from '@/utils/wordTiming'
+import type {
+  NormalizedBreak,
+  NormalizedStructuredLyric,
+} from '@/utils/wordTiming'
 
 const HUE_ROTATE_CLASSES = [
   '[filter:hue-rotate(180deg)]',
@@ -26,6 +30,8 @@ export interface WordLevelLyricsViewProps {
    * of snapping back to the future state.
    */
   lastVisitedCueByKey: Readonly<Record<string, number>>
+  /** Non-null when an instrumental break is currently active. Defaults to null. */
+  activeBreakInfo?: { breakKey: string; dotIdx: number } | null
   /** Called with the cue's normalised (offset-applied) start time in ms. */
   onWordClick: (cueStartMs: number) => void
   /** Result of resolveLyricsLang(data.lang, langCode) — computed by the container. */
@@ -34,6 +40,8 @@ export interface WordLevelLyricsViewProps {
   scrollContainerRef?: React.Ref<HTMLDivElement>
   /** Refs for each LINE CONTAINER <div> by line index — for scroll-into-view. */
   lineRefs?: React.MutableRefObject<(HTMLDivElement | null)[]>
+  /** Refs for each BREAK CONTAINER <div> by break.key — for scroll-into-view. */
+  breakContainerRefs?: React.MutableRefObject<Map<string, HTMLDivElement>>
   /**
    * Called on mount with the cue <span> element and on unmount with null, keyed
    * by `${lineIdx}|${cueLine.key}|${cueIdx}`. The container uses this to drive
@@ -41,6 +49,11 @@ export interface WordLevelLyricsViewProps {
    * React state updates so the smooth fill animation doesn't cost re-renders.
    */
   registerWordRef?: (key: string, el: HTMLSpanElement | null) => void
+  /**
+   * Same DOM-direct --fill pattern as registerWordRef but for break dots,
+   * keyed by `${break.key}|${dotIdx}`.
+   */
+  registerDotRef?: (key: string, el: HTMLSpanElement | null) => void
 }
 
 export function WordLevelLyricsView({
@@ -48,12 +61,21 @@ export function WordLevelLyricsView({
   activeLineIdx,
   activeCueByKey,
   lastVisitedCueByKey,
+  activeBreakInfo = null,
   onWordClick,
   resolvedLang,
   scrollContainerRef,
   lineRefs,
+  breakContainerRefs,
   registerWordRef,
+  registerDotRef,
 }: WordLevelLyricsViewProps) {
+  const breaksByLine = new Map<number, NormalizedBreak>()
+  for (const brk of data.breaks) {
+    breaksByLine.set(brk.beforeLineIndex, brk)
+  }
+  const isBreakActive = activeBreakInfo !== null
+
   return (
     <div
       ref={scrollContainerRef}
@@ -65,111 +87,208 @@ export function WordLevelLyricsView({
       )}
     >
       <div aria-hidden="true" style={{ height: '50%' }} />
-      {data.lines.map((line, i) => (
-        <div
-          ref={(el) => {
-            if (lineRefs?.current) lineRefs.current[i] = el
-          }}
-          key={i}
-          data-testid={`word-line-${i}`}
-          data-active={i === activeLineIdx ? 'true' : 'false'}
-          className={clsx(
-            'drop-shadow-lg my-5 duration-500 w-fit m-auto max-w-[80%] text-balance',
-            'transition-[transform] motion-reduce:transition-none',
-            i === activeLineIdx && 'scale-125',
-          )}
-        >
-          {line.cueLines.length === 0 ? (
-            <p lang={resolvedLang}>{line.value}</p>
-          ) : (
-            line.cueLines.map((cueLine) => {
-              const activeCueIdxForThisCueLine =
-                activeCueByKey[cueLine.key] ?? -1
-              const lastVisitedCueIdxForThisCueLine =
-                lastVisitedCueByKey[cueLine.key] ?? -1
-              return (
-                <p
-                  key={cueLine.key}
-                  lang={resolvedLang}
-                  dir="auto"
-                  role="text"
-                  data-testid={`word-line-${i}-cueline-${cueLine.key}`}
-                  data-agent-role={cueLine.agentRole ?? 'unknown'}
-                  data-display-order={cueLine.displayOrder}
-                >
-                  {cueLine.cues.map((cue, cueIdx) => {
-                    const renderedText = byteSliceFallback(cue, cueLine.value)
-                    const isWhitespaceOnly = renderedText.trim().length === 0
+      {data.lines.map((line, i) => {
+        const precedingBreak = breaksByLine.get(i)
+        return (
+          <Fragment key={i}>
+            {precedingBreak && (
+              <InstrumentalBreak
+                brk={precedingBreak}
+                isActive={precedingBreak.key === activeBreakInfo?.breakKey}
+                activeDotIdx={activeBreakInfo?.dotIdx ?? -1}
+                onSeek={onWordClick}
+                registerDotRef={registerDotRef}
+                containerRef={(el) => {
+                  const map = breakContainerRefs?.current
+                  if (!map) return
+                  if (el) map.set(precedingBreak.key, el)
+                  else map.delete(precedingBreak.key)
+                }}
+              />
+            )}
+            <div
+              ref={(el) => {
+                if (lineRefs?.current) lineRefs.current[i] = el
+              }}
+              data-testid={`word-line-${i}`}
+              data-active={i === activeLineIdx ? 'true' : 'false'}
+              className={clsx(
+                'drop-shadow-lg my-5 duration-500 w-fit m-auto max-w-[80%] text-balance',
+                'transition-[transform] motion-reduce:transition-none',
+                i === activeLineIdx && !isBreakActive && 'scale-125',
+              )}
+            >
+              {line.cueLines.length === 0 ? (
+                <p lang={resolvedLang}>{line.value}</p>
+              ) : (
+                line.cueLines.map((cueLine) => {
+                  const activeCueIdxForThisCueLine =
+                    activeCueByKey[cueLine.key] ?? -1
+                  const lastVisitedCueIdxForThisCueLine =
+                    lastVisitedCueByKey[cueLine.key] ?? -1
+                  return (
+                    <p
+                      key={cueLine.key}
+                      lang={resolvedLang}
+                      dir="auto"
+                      role="text"
+                      data-testid={`word-line-${i}-cueline-${cueLine.key}`}
+                      data-agent-role={cueLine.agentRole ?? 'unknown'}
+                      data-display-order={cueLine.displayOrder}
+                    >
+                      {/* NOTE: screen-reader fragmentation is a known limitation; role="text" on p partially mitigates it */}
+                      {cueLine.cues.map((cue, cueIdx) => {
+                        const renderedText = byteSliceFallback(
+                          cue,
+                          cueLine.value,
+                        )
+                        const isWhitespaceOnly =
+                          renderedText.trim().length === 0
 
-                    let cueState: 'past' | 'active' | 'future'
-                    if (i < activeLineIdx) {
-                      cueState = 'past'
-                    } else if (i === activeLineIdx) {
-                      if (cueIdx === activeCueIdxForThisCueLine) {
-                        cueState = 'active'
-                      } else if (cueIdx <= lastVisitedCueIdxForThisCueLine) {
-                        cueState = 'past'
-                      } else {
-                        cueState = 'future'
-                      }
-                    } else {
-                      cueState = 'future'
-                    }
-
-                    const hueClass =
-                      cueState === 'active' && cueLine.displayOrder >= 1
-                        ? HUE_ROTATE_CLASSES[
-                            (cueLine.displayOrder - 1) %
-                              HUE_ROTATE_CLASSES.length
-                          ]
-                        : undefined
-                    const isDim =
-                      cueState === 'past' ||
-                      (cueState === 'future' && i > activeLineIdx)
-                    const cueClassName = clsx(
-                      !isWhitespaceOnly &&
-                        'cursor-pointer hover:opacity-100 [word-break:keep-all]',
-                      isDim && 'opacity-50',
-                      cueState === 'active' && 'font-semibold',
-                      cueState === 'active' &&
-                        !isWhitespaceOnly &&
-                        'karaoke-fill',
-                      hueClass,
-                    )
-                    const wordKey = `${i}|${cueLine.key}|${cueIdx}`
-
-                    return (
-                      <span
-                        key={cueIdx}
-                        ref={(el) => registerWordRef?.(wordKey, el)}
-                        data-testid={`word-${i}-${cueLine.key}-${cueIdx}`}
-                        data-state={cueState}
-                        aria-hidden={isWhitespaceOnly ? 'true' : undefined}
-                        className={cueClassName}
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          onWordClick(cue.start)
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault()
-                            onWordClick(cue.start)
+                        let cueState: 'past' | 'active' | 'future'
+                        if (i < activeLineIdx) {
+                          cueState = 'past'
+                        } else if (i === activeLineIdx) {
+                          if (cueIdx === activeCueIdxForThisCueLine) {
+                            cueState = 'active'
+                          } else if (
+                            cueIdx <= lastVisitedCueIdxForThisCueLine
+                          ) {
+                            cueState = 'past'
+                          } else {
+                            cueState = 'future'
                           }
-                        }}
-                        tabIndex={isWhitespaceOnly ? -1 : 0}
-                      >
-                        {renderedText}
-                      </span>
-                    )
-                  })}
-                </p>
-              )
-            })
-          )}
-        </div>
-      ))}
+                        } else {
+                          cueState = 'future'
+                        }
+
+                        const hueClass =
+                          cueState === 'active' && cueLine.displayOrder >= 1
+                            ? HUE_ROTATE_CLASSES[
+                                (cueLine.displayOrder - 1) %
+                                  HUE_ROTATE_CLASSES.length
+                              ]
+                            : undefined
+                        const isDim =
+                          cueState === 'past' ||
+                          (cueState === 'future' && i > activeLineIdx)
+                        const cueClassName = clsx(
+                          !isWhitespaceOnly &&
+                            'cursor-pointer hover:opacity-100 [word-break:keep-all]',
+                          isDim && 'opacity-50',
+                          cueState === 'active' && 'font-semibold',
+                          cueState === 'active' &&
+                            !isWhitespaceOnly &&
+                            'karaoke-fill',
+                          hueClass,
+                        )
+                        const wordKey = `${i}|${cueLine.key}|${cueIdx}`
+
+                        return (
+                          <span
+                            key={cueIdx}
+                            ref={(el) => registerWordRef?.(wordKey, el)}
+                            data-testid={`word-${i}-${cueLine.key}-${cueIdx}`}
+                            data-state={cueState}
+                            aria-hidden={isWhitespaceOnly ? 'true' : undefined}
+                            className={cueClassName}
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              onWordClick(cue.start)
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                onWordClick(cue.start)
+                              }
+                            }}
+                            tabIndex={isWhitespaceOnly ? -1 : 0}
+                          >
+                            {renderedText}
+                          </span>
+                        )
+                      })}
+                    </p>
+                  )
+                })
+              )}
+            </div>
+          </Fragment>
+        )
+      })}
       {/* Bottom spacer mirrors react-lrc's verticalSpace=true — lets the last line scroll to center */}
       <div aria-hidden="true" style={{ height: '50%' }} />
+    </div>
+  )
+}
+
+function InstrumentalBreak({
+  brk,
+  isActive,
+  activeDotIdx,
+  onSeek,
+  registerDotRef,
+  containerRef,
+}: {
+  brk: NormalizedBreak
+  isActive: boolean
+  activeDotIdx: number
+  onSeek: (timeMs: number) => void
+  registerDotRef?: (key: string, el: HTMLSpanElement | null) => void
+  containerRef?: (el: HTMLDivElement | null) => void
+}) {
+  const durationPerDot = (brk.end - brk.start) / brk.dotCount
+  return (
+    <div
+      ref={containerRef}
+      data-testid={`instrumental-break-${brk.key}`}
+      data-active={isActive ? 'true' : 'false'}
+      className={clsx(
+        'drop-shadow-lg my-5 duration-500 w-fit m-auto',
+        'transition-[transform] motion-reduce:transition-none',
+        isActive && 'scale-125',
+      )}
+    >
+      <p className="flex flex-wrap items-center justify-center text-2xl 2xl:text-3xl font-semibold leading-none">
+        {Array.from({ length: brk.dotCount }, (_, idx) => {
+          const dotKey = `${brk.key}|${idx}`
+          const dotStartMs = brk.start + idx * durationPerDot
+          const isActiveDot = isActive && idx === activeDotIdx
+          // Breaks <=5 dots: all spaced. Breaks >5 dots: only the LAST 5 dots
+          // get spacing (pack the silence as a dense block, space the final
+          // countdown). idx>0 guards the first dot from a leading margin.
+          const isInSpacedZone = brk.dotCount <= 5 || idx >= brk.dotCount - 5
+          return (
+            <span
+              key={idx}
+              ref={(el) => registerDotRef?.(dotKey, el)}
+              data-testid={`instrumental-break-${brk.key}-dot-${idx}`}
+              data-state={isActiveDot ? 'active' : 'inactive'}
+              role="button"
+              aria-label={`Seek to ${Math.round(dotStartMs / 1000)} seconds`}
+              tabIndex={0}
+              onClick={(e) => {
+                e.stopPropagation()
+                onSeek(dotStartMs)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  onSeek(dotStartMs)
+                }
+              }}
+              className={clsx(
+                'cursor-pointer hover:opacity-100',
+                isInSpacedZone && idx > 0 && 'ml-3',
+                !isActiveDot && 'opacity-50',
+                isActiveDot && 'karaoke-fill',
+              )}
+            >
+              ·
+            </span>
+          )
+        })}
+      </p>
     </div>
   )
 }

--- a/src/app/components/settings/pages/audio/lyrics.tsx
+++ b/src/app/components/settings/pages/audio/lyrics.tsx
@@ -15,7 +15,17 @@ import { useLyricsSettings } from '@/store/player.store'
 
 export function LyricsSettings() {
   const { t } = useTranslation()
-  const { preferSyncedLyrics, setPreferSyncedLyrics } = useLyricsSettings()
+  const {
+    preferSyncedLyrics,
+    setPreferSyncedLyrics,
+    preferWordLevelLyrics,
+    setPreferWordLevelLyrics,
+  } = useLyricsSettings()
+
+  const handleWordLevelToggle = (value: boolean) => {
+    setPreferWordLevelLyrics(value)
+    if (value) setPreferSyncedLyrics(true)
+  }
 
   return (
     <Root>
@@ -34,6 +44,20 @@ export function LyricsSettings() {
             <Switch
               checked={preferSyncedLyrics}
               onCheckedChange={setPreferSyncedLyrics}
+              disabled={preferWordLevelLyrics}
+            />
+          </ContentItemForm>
+        </ContentItem>
+        <ContentItem>
+          <ContentItemTitle
+            info={t('settings.audio.lyrics.preferWordLevel.info')}
+          >
+            {t('settings.audio.lyrics.preferWordLevel.label')}
+          </ContentItemTitle>
+          <ContentItemForm>
+            <Switch
+              checked={preferWordLevelLyrics}
+              onCheckedChange={handleWordLevelToggle}
             />
           </ContentItemForm>
         </ContentItem>

--- a/src/hooks/use-raf-active-cue.ts
+++ b/src/hooks/use-raf-active-cue.ts
@@ -1,0 +1,192 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+export interface UseRafActiveCueArgs {
+  lines: ReadonlyArray<{
+    start?: number
+    end?: number
+    cueLines: ReadonlyArray<{
+      key: string
+      start?: number
+      end?: number
+      cues: ReadonlyArray<{ start: number; end: number }>
+    }>
+  }>
+  getCurrentTimeMs: () => number
+  enabled?: boolean
+}
+
+export interface UseRafActiveCueResult {
+  activeLineIdx: number
+  activeCueByKey: Readonly<Record<string, number>>
+  lastVisitedCueByKey: Readonly<Record<string, number>>
+}
+
+/**
+ * Binary search: returns the index `i` of the greatest `lineStarts[i] <= t`.
+ * Returns -1 if `t` is before the first start or the array is empty.
+ */
+export function findLineIdx(lineStarts: number[], t: number): number {
+  let lo = 0
+  let hi = lineStarts.length - 1
+  let result = -1
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1
+    if (lineStarts[mid] <= t) {
+      result = mid
+      lo = mid + 1
+    } else {
+      hi = mid - 1
+    }
+  }
+  return result
+}
+
+/**
+ * Binary search: returns index `i` where `cueStarts[i] <= t < cueEnds[i]`.
+ * Returns -1 if `t` is in a gap between cues, before all cues, or after all cues.
+ */
+export function findCueIdx(
+  cueStarts: number[],
+  cueEnds: number[],
+  t: number,
+): number {
+  let lo = 0
+  let hi = cueStarts.length - 1
+  let candidate = -1
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1
+    if (cueStarts[mid] <= t) {
+      candidate = mid
+      lo = mid + 1
+    } else {
+      hi = mid - 1
+    }
+  }
+  if (candidate >= 0 && t < cueEnds[candidate]) return candidate
+  return -1
+}
+
+/**
+ * Tracks the currently-active lyric line and the active cue (per agent key)
+ * by polling `getCurrentTimeMs()` once per animation frame.
+ *
+ * - Loop lives inside `useEffect`; cleanup calls `cancelAnimationFrame`.
+ * - Skips work when `document.hidden` is true (background tab).
+ * - Only calls `setState` when an active index actually changes.
+ * - Uses binary search over pre-computed sorted start/end arrays.
+ */
+export function useRafActiveCue({
+  lines,
+  getCurrentTimeMs,
+  enabled = true,
+}: UseRafActiveCueArgs): UseRafActiveCueResult {
+  const [activeLineIdx, setActiveLineIdx] = useState(-1)
+  const [activeCueByKey, setActiveCueByKey] = useState<Record<string, number>>(
+    {},
+  )
+  const [lastVisitedCueByKey, setLastVisitedCueByKey] = useState<
+    Record<string, number>
+  >({})
+  const rafIdRef = useRef<number | null>(null)
+  const mountedRef = useRef(true)
+  const lineIdxRef = useRef(-1)
+  const cueByKeyRef = useRef<Record<string, number>>({})
+  const lastVisitedRef = useRef<Record<string, number>>({})
+
+  // Pre-compute sorted arrays for binary search (memoized by line identity).
+  const lineStarts = useMemo(() => lines.map((l) => l.start ?? 0), [lines])
+  const cueDataByLine = useMemo(
+    () =>
+      lines.map((l) =>
+        l.cueLines.map((cl) => ({
+          key: cl.key,
+          starts: cl.cues.map((c) => c.start),
+          ends: cl.cues.map((c) => c.end),
+        })),
+      ),
+    [lines],
+  )
+
+  useEffect(() => {
+    mountedRef.current = true
+
+    if (!enabled || lines.length === 0) {
+      setActiveLineIdx(-1)
+      setActiveCueByKey({})
+      setLastVisitedCueByKey({})
+      lineIdxRef.current = -1
+      cueByKeyRef.current = {}
+      lastVisitedRef.current = {}
+      return
+    }
+
+    const tick = () => {
+      if (!mountedRef.current) return
+
+      // Skip all work in background tabs to avoid wasted CPU.
+      if (document.hidden) {
+        rafIdRef.current = requestAnimationFrame(tick)
+        return
+      }
+
+      const t = getCurrentTimeMs()
+      const newLineIdx = findLineIdx(lineStarts, t)
+      const newCueByKey: Record<string, number> = {}
+      const newLastVisited: Record<string, number> = {}
+
+      if (newLineIdx >= 0) {
+        const cueLines = cueDataByLine[newLineIdx]
+        for (const cl of cueLines) {
+          const cueIdx = findCueIdx(cl.starts, cl.ends, t)
+          if (cueIdx >= 0) {
+            newCueByKey[cl.key] = cueIdx
+          }
+          const visitedIdx = findLineIdx(cl.starts, t)
+          if (visitedIdx >= 0) {
+            newLastVisited[cl.key] = visitedIdx
+          }
+        }
+      }
+
+      // Only setState when the active line index actually changes.
+      if (newLineIdx !== lineIdxRef.current) {
+        lineIdxRef.current = newLineIdx
+        if (mountedRef.current) setActiveLineIdx(newLineIdx)
+      }
+
+      const prevKeys = Object.keys(cueByKeyRef.current)
+      const newKeys = Object.keys(newCueByKey)
+      const cueChanged =
+        prevKeys.length !== newKeys.length ||
+        newKeys.some((k) => cueByKeyRef.current[k] !== newCueByKey[k])
+      if (cueChanged) {
+        cueByKeyRef.current = newCueByKey
+        if (mountedRef.current) setActiveCueByKey(newCueByKey)
+      }
+
+      const prevVisKeys = Object.keys(lastVisitedRef.current)
+      const newVisKeys = Object.keys(newLastVisited)
+      const visChanged =
+        prevVisKeys.length !== newVisKeys.length ||
+        newVisKeys.some((k) => lastVisitedRef.current[k] !== newLastVisited[k])
+      if (visChanged) {
+        lastVisitedRef.current = newLastVisited
+        if (mountedRef.current) setLastVisitedCueByKey(newLastVisited)
+      }
+
+      rafIdRef.current = requestAnimationFrame(tick)
+    }
+
+    rafIdRef.current = requestAnimationFrame(tick)
+
+    return () => {
+      mountedRef.current = false
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current)
+        rafIdRef.current = null
+      }
+    }
+  }, [lines, lineStarts, cueDataByLine, getCurrentTimeMs, enabled])
+
+  return { activeLineIdx, activeCueByKey, lastVisitedCueByKey }
+}

--- a/src/hooks/use-raf-active-cue.ts
+++ b/src/hooks/use-raf-active-cue.ts
@@ -3,9 +3,11 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 export interface RafTickInfo {
   /** Current playback time in ms (offset already applied upstream by the caller). */
   t: number
-  /** -1 when no line is active. */
+  /** -1 when no line has started; else the rightmost-started line index (boundary for past/future). */
   activeLineIdx: number
-  /** Map from NormalizedCueLine.key → active cue index. Empty when no line active. */
+  /** Asc-sorted indices of all currently-overlapping lines; falls back to [activeLineIdx] in inter-line gaps; empty before first line. */
+  activeLineIndices: ReadonlyArray<number>
+  /** Map from NormalizedCueLine.key → active cue index. Aggregated across every line in activeLineIndices. */
   activeCueByKey: Readonly<Record<string, number>>
 }
 
@@ -37,6 +39,8 @@ export interface UseRafActiveCueArgs {
 
 export interface UseRafActiveCueResult {
   activeLineIdx: number
+  /** All currently-active line indices in ascending order. See RafTickInfo for semantics. */
+  activeLineIndices: ReadonlyArray<number>
   activeCueByKey: Readonly<Record<string, number>>
   lastVisitedCueByKey: Readonly<Record<string, number>>
 }
@@ -87,6 +91,39 @@ export function findCueIdx(
 }
 
 /**
+ * Returns asc-sorted indices of every line whose [start, end) range contains t
+ * (the cluster of concurrent voices currently sounding). When the playhead sits
+ * in an inter-line gap, falls back to `[rightmost]` so a single line stays
+ * visually active until the next starts — preserves pre-cluster behaviour for
+ * non-overlapping lyrics. Returns `[]` only before the very first line.
+ *
+ * Uses `prefixMaxEnd` (running max of lineEnds) to bound the backward scan: any
+ * `j` with `prefixMaxEnd[j] <= t` proves no line at `j` or earlier can still
+ * overlap, terminating the scan early. Per-frame cost is O(cluster size),
+ * typically ≤ ~5 even on dense duet sections.
+ */
+export function findActiveLineIndices(
+  lineStarts: number[],
+  lineEnds: number[],
+  prefixMaxEnd: number[],
+  t: number,
+): number[] {
+  if (lineStarts.length === 0) return []
+  const rightmost = findLineIdx(lineStarts, t)
+  if (rightmost < 0) return []
+  const overlapping: number[] = []
+  for (let j = rightmost; j >= 0; j--) {
+    if (prefixMaxEnd[j] <= t) break
+    if (t < lineEnds[j]) overlapping.push(j)
+  }
+  if (overlapping.length === 0) return [rightmost]
+  overlapping.reverse()
+  return overlapping
+}
+
+const EMPTY_ACTIVE_INDICES: ReadonlyArray<number> = Object.freeze([])
+
+/**
  * Tracks the currently-active lyric line and the active cue (per agent key)
  * by polling `getCurrentTimeMs()` once per animation frame.
  *
@@ -102,6 +139,8 @@ export function useRafActiveCue({
   onTick,
 }: UseRafActiveCueArgs): UseRafActiveCueResult {
   const [activeLineIdx, setActiveLineIdx] = useState(-1)
+  const [activeLineIndices, setActiveLineIndices] =
+    useState<ReadonlyArray<number>>(EMPTY_ACTIVE_INDICES)
   const [activeCueByKey, setActiveCueByKey] = useState<Record<string, number>>(
     {},
   )
@@ -111,6 +150,8 @@ export function useRafActiveCue({
   const rafIdRef = useRef<number | null>(null)
   const mountedRef = useRef(true)
   const lineIdxRef = useRef(-1)
+  const activeIndicesRef =
+    useRef<ReadonlyArray<number>>(EMPTY_ACTIVE_INDICES)
   const cueByKeyRef = useRef<Record<string, number>>({})
   const lastVisitedRef = useRef<Record<string, number>>({})
   const onTickRef = useRef(onTick)
@@ -119,7 +160,24 @@ export function useRafActiveCue({
   }, [onTick])
 
   // Pre-compute sorted arrays for binary search (memoized by line identity).
+  // lineEnds uses -Infinity for lines lacking an end (cueLine-less placeholder
+  // lines): `t < -Infinity` is always false, so such lines are never reported
+  // as overlapping. prefixMaxEnd is the running max of lineEnds, used by
+  // findActiveLineIndices to bound the backward overlap scan.
   const lineStarts = useMemo(() => lines.map((l) => l.start ?? 0), [lines])
+  const lineEnds = useMemo(
+    () => lines.map((l) => l.end ?? Number.NEGATIVE_INFINITY),
+    [lines],
+  )
+  const prefixMaxEnd = useMemo(() => {
+    const out = new Array<number>(lineEnds.length)
+    let max = Number.NEGATIVE_INFINITY
+    for (let i = 0; i < lineEnds.length; i++) {
+      if (lineEnds[i] > max) max = lineEnds[i]
+      out[i] = max
+    }
+    return out
+  }, [lineEnds])
   const cueDataByLine = useMemo(
     () =>
       lines.map((l) =>
@@ -137,9 +195,11 @@ export function useRafActiveCue({
 
     if (!enabled || lines.length === 0) {
       setActiveLineIdx(-1)
+      setActiveLineIndices(EMPTY_ACTIVE_INDICES)
       setActiveCueByKey({})
       setLastVisitedCueByKey({})
       lineIdxRef.current = -1
+      activeIndicesRef.current = EMPTY_ACTIVE_INDICES
       cueByKeyRef.current = {}
       lastVisitedRef.current = {}
       return
@@ -155,27 +215,37 @@ export function useRafActiveCue({
       }
 
       const t = getCurrentTimeMs()
+      // Rightmost-started line: stable back-compat anchor and past/future boundary
+      // for the view. activeLineIndices is the cluster overlap set (may equal
+      // [activeLineIdx] in gaps, may be multi-element across concurrent voices).
       const newLineIdx = findLineIdx(lineStarts, t)
+      const newActiveIndices = findActiveLineIndices(
+        lineStarts,
+        lineEnds,
+        prefixMaxEnd,
+        t,
+      )
       const newCueByKey: Record<string, number> = {}
       const newLastVisited: Record<string, number> = {}
 
-      if (newLineIdx >= 0) {
-        const cueLines = cueDataByLine[newLineIdx]
+      // Aggregate cue maps across EVERY active line. Keys are globally unique
+      // (line index baked into NormalizedCueLine.key) so collisions are
+      // impossible and concurrent voices each keep their own active-cue index.
+      for (const lineIdx of newActiveIndices) {
+        const cueLines = cueDataByLine[lineIdx]
+        if (!cueLines) continue
         for (const cl of cueLines) {
           const cueIdx = findCueIdx(cl.starts, cl.ends, t)
-          if (cueIdx >= 0) {
-            newCueByKey[cl.key] = cueIdx
-          }
+          if (cueIdx >= 0) newCueByKey[cl.key] = cueIdx
           const visitedIdx = findLineIdx(cl.starts, t)
-          if (visitedIdx >= 0) {
-            newLastVisited[cl.key] = visitedIdx
-          }
+          if (visitedIdx >= 0) newLastVisited[cl.key] = visitedIdx
         }
       }
 
       onTickRef.current?.({
         t,
         activeLineIdx: newLineIdx,
+        activeLineIndices: newActiveIndices,
         activeCueByKey: newCueByKey,
       })
 
@@ -183,6 +253,16 @@ export function useRafActiveCue({
       if (newLineIdx !== lineIdxRef.current) {
         lineIdxRef.current = newLineIdx
         if (mountedRef.current) setActiveLineIdx(newLineIdx)
+      }
+
+      // activeLineIndices change detection — same-length, same-elements check.
+      const prevIndices = activeIndicesRef.current
+      const indicesChanged =
+        prevIndices.length !== newActiveIndices.length ||
+        prevIndices.some((v, i) => v !== newActiveIndices[i])
+      if (indicesChanged) {
+        activeIndicesRef.current = newActiveIndices
+        if (mountedRef.current) setActiveLineIndices(newActiveIndices)
       }
 
       const prevKeys = Object.keys(cueByKeyRef.current)
@@ -217,7 +297,20 @@ export function useRafActiveCue({
         rafIdRef.current = null
       }
     }
-  }, [lines, lineStarts, cueDataByLine, getCurrentTimeMs, enabled])
+  }, [
+    lines,
+    lineStarts,
+    lineEnds,
+    prefixMaxEnd,
+    cueDataByLine,
+    getCurrentTimeMs,
+    enabled,
+  ])
 
-  return { activeLineIdx, activeCueByKey, lastVisitedCueByKey }
+  return {
+    activeLineIdx,
+    activeLineIndices,
+    activeCueByKey,
+    lastVisitedCueByKey,
+  }
 }

--- a/src/hooks/use-raf-active-cue.ts
+++ b/src/hooks/use-raf-active-cue.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export interface RafTickInfo {
   /** Current playback time in ms (offset already applied upstream by the caller). */
@@ -123,13 +123,48 @@ export function findActiveLineIndices(
 
 const EMPTY_ACTIVE_INDICES: ReadonlyArray<number> = Object.freeze([])
 
+const indicesEqual = (
+  a: ReadonlyArray<number>,
+  b: ReadonlyArray<number>,
+): boolean => a.length === b.length && a.every((v, i) => v === b[i])
+
+const recordEqual = (
+  a: Record<string, number>,
+  b: Record<string, number>,
+): boolean => {
+  const ka = Object.keys(a)
+  const kb = Object.keys(b)
+  return ka.length === kb.length && ka.every((k) => a[k] === b[k])
+}
+
+/**
+ * `useState` + a ref shadow + caller-supplied equality. `commit(next)` only
+ * dispatches a setState (and updates the ref) when `next` differs from the
+ * previously-committed value. Lets the rAF tick call this every frame and
+ * cheaply skip work when nothing has changed.
+ */
+function useReactiveValue<T>(
+  initial: T,
+  equal: (a: T, b: T) => boolean = Object.is as (a: T, b: T) => boolean,
+): [T, (next: T) => void] {
+  const [state, setState] = useState<T>(initial)
+  const ref = useRef<T>(initial)
+  const commit = (next: T) => {
+    if (!equal(ref.current, next)) {
+      ref.current = next
+      setState(next)
+    }
+  }
+  return [state, commit]
+}
+
 /**
  * Tracks the currently-active lyric line and the active cue (per agent key)
  * by polling `getCurrentTimeMs()` once per animation frame.
  *
  * - Loop lives inside `useEffect`; cleanup calls `cancelAnimationFrame`.
  * - Skips work when `document.hidden` is true (background tab).
- * - Only calls `setState` when an active index actually changes.
+ * - Only re-renders when an active index actually changes.
  * - Uses binary search over pre-computed sorted start/end arrays.
  */
 export function useRafActiveCue({
@@ -138,86 +173,66 @@ export function useRafActiveCue({
   enabled = true,
   onTick,
 }: UseRafActiveCueArgs): UseRafActiveCueResult {
-  const [activeLineIdx, setActiveLineIdx] = useState(-1)
-  const [activeLineIndices, setActiveLineIndices] =
-    useState<ReadonlyArray<number>>(EMPTY_ACTIVE_INDICES)
-  const [activeCueByKey, setActiveCueByKey] = useState<Record<string, number>>(
-    {},
-  )
-  const [lastVisitedCueByKey, setLastVisitedCueByKey] = useState<
+  const [activeLineIdx, commitActiveLineIdx] = useReactiveValue<number>(-1)
+  const [activeLineIndices, commitActiveLineIndices] = useReactiveValue<
+    ReadonlyArray<number>
+  >(EMPTY_ACTIVE_INDICES, indicesEqual)
+  const [activeCueByKey, commitActiveCueByKey] = useReactiveValue<
     Record<string, number>
-  >({})
-  const rafIdRef = useRef<number | null>(null)
-  const mountedRef = useRef(true)
-  const lineIdxRef = useRef(-1)
-  const activeIndicesRef =
-    useRef<ReadonlyArray<number>>(EMPTY_ACTIVE_INDICES)
-  const cueByKeyRef = useRef<Record<string, number>>({})
-  const lastVisitedRef = useRef<Record<string, number>>({})
+  >({}, recordEqual)
+  const [lastVisitedCueByKey, commitLastVisitedCueByKey] = useReactiveValue<
+    Record<string, number>
+  >({}, recordEqual)
+
+  // Stable callback ref — lets the caller pass a fresh inline `onTick` each
+  // render without restarting the rAF loop.
   const onTickRef = useRef(onTick)
   useEffect(() => {
     onTickRef.current = onTick
   }, [onTick])
 
-  // Pre-compute sorted arrays for binary search (memoized by line identity).
-  // lineEnds uses -Infinity for lines lacking an end (cueLine-less placeholder
-  // lines): `t < -Infinity` is always false, so such lines are never reported
-  // as overlapping. prefixMaxEnd is the running max of lineEnds, used by
-  // findActiveLineIndices to bound the backward overlap scan.
-  const lineStarts = useMemo(() => lines.map((l) => l.start ?? 0), [lines])
-  const lineEnds = useMemo(
-    () => lines.map((l) => l.end ?? Number.NEGATIVE_INFINITY),
-    [lines],
-  )
-  const prefixMaxEnd = useMemo(() => {
-    const out = new Array<number>(lineEnds.length)
-    let max = Number.NEGATIVE_INFINITY
-    for (let i = 0; i < lineEnds.length; i++) {
-      if (lineEnds[i] > max) max = lineEnds[i]
-      out[i] = max
-    }
-    return out
-  }, [lineEnds])
-  const cueDataByLine = useMemo(
-    () =>
-      lines.map((l) =>
-        l.cueLines.map((cl) => ({
-          key: cl.key,
-          starts: cl.cues.map((c) => c.start),
-          ends: cl.cues.map((c) => c.end),
-        })),
-      ),
-    [lines],
-  )
-
+  // biome-ignore lint/correctness/useExhaustiveDependencies: commit fns close over stable refs/setStates and don't drive the loop
   useEffect(() => {
-    mountedRef.current = true
-
     if (!enabled || lines.length === 0) {
-      setActiveLineIdx(-1)
-      setActiveLineIndices(EMPTY_ACTIVE_INDICES)
-      setActiveCueByKey({})
-      setLastVisitedCueByKey({})
-      lineIdxRef.current = -1
-      activeIndicesRef.current = EMPTY_ACTIVE_INDICES
-      cueByKeyRef.current = {}
-      lastVisitedRef.current = {}
+      commitActiveLineIdx(-1)
+      commitActiveLineIndices(EMPTY_ACTIVE_INDICES)
+      commitActiveCueByKey({})
+      commitLastVisitedCueByKey({})
       return
     }
 
-    const tick = () => {
-      if (!mountedRef.current) return
+    // Pre-compute sorted arrays for binary search. lineEnds uses -Infinity for
+    // placeholder lines lacking an end so `t < -Infinity` is always false and
+    // those lines are never reported as overlapping. prefixMaxEnd (running max
+    // of lineEnds) bounds the backward overlap scan in findActiveLineIndices.
+    const lineStarts = lines.map((l) => l.start ?? 0)
+    const lineEnds = lines.map((l) => l.end ?? Number.NEGATIVE_INFINITY)
+    const prefixMaxEnd = new Array<number>(lineEnds.length)
+    {
+      let max = Number.NEGATIVE_INFINITY
+      for (let i = 0; i < lineEnds.length; i++) {
+        if (lineEnds[i] > max) max = lineEnds[i]
+        prefixMaxEnd[i] = max
+      }
+    }
+    const cueDataByLine = lines.map((l) =>
+      l.cueLines.map((cl) => ({
+        key: cl.key,
+        starts: cl.cues.map((c) => c.start),
+        ends: cl.cues.map((c) => c.end),
+      })),
+    )
 
+    let rafId = requestAnimationFrame(tick)
+
+    function tick() {
       // Skip all work in background tabs to avoid wasted CPU.
       if (document.hidden) {
-        rafIdRef.current = requestAnimationFrame(tick)
+        rafId = requestAnimationFrame(tick)
         return
       }
 
       const t = getCurrentTimeMs()
-      // Rightmost-started line: stable back-compat anchor and past/future boundary
-      // for the view. activeLineIndices is the cluster overlap set (may equal
-      // [activeLineIdx] in gaps, may be multi-element across concurrent voices).
       const newLineIdx = findLineIdx(lineStarts, t)
       const newActiveIndices = findActiveLineIndices(
         lineStarts,
@@ -249,63 +264,18 @@ export function useRafActiveCue({
         activeCueByKey: newCueByKey,
       })
 
-      // Only setState when the active line index actually changes.
-      if (newLineIdx !== lineIdxRef.current) {
-        lineIdxRef.current = newLineIdx
-        if (mountedRef.current) setActiveLineIdx(newLineIdx)
-      }
+      commitActiveLineIdx(newLineIdx)
+      commitActiveLineIndices(newActiveIndices)
+      commitActiveCueByKey(newCueByKey)
+      commitLastVisitedCueByKey(newLastVisited)
 
-      // activeLineIndices change detection — same-length, same-elements check.
-      const prevIndices = activeIndicesRef.current
-      const indicesChanged =
-        prevIndices.length !== newActiveIndices.length ||
-        prevIndices.some((v, i) => v !== newActiveIndices[i])
-      if (indicesChanged) {
-        activeIndicesRef.current = newActiveIndices
-        if (mountedRef.current) setActiveLineIndices(newActiveIndices)
-      }
-
-      const prevKeys = Object.keys(cueByKeyRef.current)
-      const newKeys = Object.keys(newCueByKey)
-      const cueChanged =
-        prevKeys.length !== newKeys.length ||
-        newKeys.some((k) => cueByKeyRef.current[k] !== newCueByKey[k])
-      if (cueChanged) {
-        cueByKeyRef.current = newCueByKey
-        if (mountedRef.current) setActiveCueByKey(newCueByKey)
-      }
-
-      const prevVisKeys = Object.keys(lastVisitedRef.current)
-      const newVisKeys = Object.keys(newLastVisited)
-      const visChanged =
-        prevVisKeys.length !== newVisKeys.length ||
-        newVisKeys.some((k) => lastVisitedRef.current[k] !== newLastVisited[k])
-      if (visChanged) {
-        lastVisitedRef.current = newLastVisited
-        if (mountedRef.current) setLastVisitedCueByKey(newLastVisited)
-      }
-
-      rafIdRef.current = requestAnimationFrame(tick)
+      rafId = requestAnimationFrame(tick)
     }
-
-    rafIdRef.current = requestAnimationFrame(tick)
 
     return () => {
-      mountedRef.current = false
-      if (rafIdRef.current !== null) {
-        cancelAnimationFrame(rafIdRef.current)
-        rafIdRef.current = null
-      }
+      cancelAnimationFrame(rafId)
     }
-  }, [
-    lines,
-    lineStarts,
-    lineEnds,
-    prefixMaxEnd,
-    cueDataByLine,
-    getCurrentTimeMs,
-    enabled,
-  ])
+  }, [lines, getCurrentTimeMs, enabled])
 
   return {
     activeLineIdx,

--- a/src/hooks/use-raf-active-cue.ts
+++ b/src/hooks/use-raf-active-cue.ts
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 
+export interface RafTickInfo {
+  /** Current playback time in ms (offset already applied upstream by the caller). */
+  t: number
+  /** -1 when no line is active. */
+  activeLineIdx: number
+  /** Map from NormalizedCueLine.key → active cue index. Empty when no line active. */
+  activeCueByKey: Readonly<Record<string, number>>
+}
+
 export interface UseRafActiveCueArgs {
   lines: ReadonlyArray<{
     start?: number
@@ -13,6 +22,17 @@ export interface UseRafActiveCueArgs {
   }>
   getCurrentTimeMs: () => number
   enabled?: boolean
+  /**
+   * Fired on EVERY animation frame (when the document is visible), AFTER the
+   * active-index binary searches but BEFORE any `setState` calls. This is the
+   * side-channel for sub-cue-resolution effects (e.g. karaoke wipe progress)
+   * that need a smooth 60fps signal without triggering React re-renders.
+   *
+   * The callback identity is stored in a ref so changing it on every render is
+   * cheap (no RAF restart). Implementations should treat it as fire-and-forget
+   * and avoid heavy work inside.
+   */
+  onTick?: (info: RafTickInfo) => void
 }
 
 export interface UseRafActiveCueResult {
@@ -79,6 +99,7 @@ export function useRafActiveCue({
   lines,
   getCurrentTimeMs,
   enabled = true,
+  onTick,
 }: UseRafActiveCueArgs): UseRafActiveCueResult {
   const [activeLineIdx, setActiveLineIdx] = useState(-1)
   const [activeCueByKey, setActiveCueByKey] = useState<Record<string, number>>(
@@ -92,6 +113,10 @@ export function useRafActiveCue({
   const lineIdxRef = useRef(-1)
   const cueByKeyRef = useRef<Record<string, number>>({})
   const lastVisitedRef = useRef<Record<string, number>>({})
+  const onTickRef = useRef(onTick)
+  useEffect(() => {
+    onTickRef.current = onTick
+  }, [onTick])
 
   // Pre-compute sorted arrays for binary search (memoized by line identity).
   const lineStarts = useMemo(() => lines.map((l) => l.start ?? 0), [lines])
@@ -147,6 +172,12 @@ export function useRafActiveCue({
           }
         }
       }
+
+      onTickRef.current?.({
+        t,
+        activeLineIdx: newLineIdx,
+        activeCueByKey: newCueByKey,
+      })
 
       // Only setState when the active line index actually changes.
       if (newLineIdx !== lineIdxRef.current) {

--- a/src/hooks/use-word-seek.ts
+++ b/src/hooks/use-word-seek.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react'
+import { usePlayerRef } from '@/store/player.store'
+
+/**
+ * Returns a stable callback that seeks audio playback to a word's start time.
+ * `cueStartMs` must already have the structuredLyric offset baked in (done by wordTiming normalizer).
+ */
+export function useWordSeek(): (cueStartMs: number) => void {
+  const playerRef = usePlayerRef()
+
+  return useCallback(
+    (cueStartMs: number) => {
+      if (!playerRef || cueStartMs < 0) return
+      const seconds = cueStartMs / 1000
+      playerRef.currentTime = Math.max(
+        0,
+        Math.min(seconds, playerRef.duration || Infinity),
+      )
+    },
+    [playerRef],
+  )
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -678,6 +678,10 @@
         "preferSynced": {
           "label": "Prefer synced lyrics",
           "info": "When enabled, synced lyrics will be prioritized over unsynced lyrics."
+        },
+        "preferWordLevel": {
+          "label": "Prefer word-level synced lyrics",
+          "info": "When enabled, word-by-word highlighting is used when the server supports providing word-level timing data."
         }
       }
     },

--- a/src/index.css
+++ b/src/index.css
@@ -351,6 +351,28 @@ svg#bars .eq-bar--4 {
   @apply w-fit m-auto max-w-[80%] text-balance;
 }
 
+/*
+ * Karaoke wipe on the active word-level cue. Driven by --fill (a percentage)
+ * written each animation frame by container.tsx's handleTick. The gradient
+ * stops have a ±3% feather so the boundary reads as a soft edge rather than a
+ * hard line. `currentColor` for the unfilled half means the not-yet-sung
+ * portion blends with surrounding cue text. `-webkit-text-fill-color:
+ * transparent` makes the glyph see-through so background-clip:text reveals
+ * the gradient through the letterforms.
+ */
+.karaoke-fill {
+  background-image: linear-gradient(
+    90deg,
+    hsl(var(--primary)) 0%,
+    hsl(var(--primary)) calc(var(--fill, 0%) - 3%),
+    currentColor calc(var(--fill, 0%) + 3%),
+    currentColor 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
 .default-gradient {
   @apply bg-gradient-to-b from-background/10 to-background/40;
 }

--- a/src/service/lyrics.ts
+++ b/src/service/lyrics.ts
@@ -12,7 +12,7 @@ import {
 } from '@/types/responses/song'
 import { lrclibClient } from '@/utils/appName'
 import { checkServerType, getServerExtensions } from '@/utils/servers'
-import { pickPrimaryStructuredLyric } from '@/utils/wordTiming'
+import { pickPrimarySyncedStructuredLyric } from '@/utils/wordTiming'
 
 type LyricsResult = ILyric & {
   structuredLyric?: IStructuredLyric
@@ -102,10 +102,7 @@ async function getLyrics(
       const { structuredLyrics } = response.data.lyricsList
 
       if (structuredLyrics && structuredLyrics.length > 0) {
-        const primary = pickPrimaryStructuredLyric(structuredLyrics)
-        const syncedLyrics = primary?.synced
-          ? primary
-          : structuredLyrics.find((l) => l.synced)
+        const syncedLyrics = pickPrimarySyncedStructuredLyric(structuredLyrics)
 
         if (syncedLyrics) {
           const serverSyncedLyrics: LyricsResult = {

--- a/src/service/lyrics.ts
+++ b/src/service/lyrics.ts
@@ -12,6 +12,11 @@ import {
 } from '@/types/responses/song'
 import { lrclibClient } from '@/utils/appName'
 import { checkServerType, getServerExtensions } from '@/utils/servers'
+import { pickPrimaryStructuredLyric } from '@/utils/wordTiming'
+
+type LyricsResult = ILyric & {
+  structuredLyric?: IStructuredLyric
+}
 
 // normalizes the ISO 639 code returned by the server to the BCP 47 language tag recognized by the html lang selector
 function normalizeLangCode(lang: string | undefined): string | undefined {
@@ -45,15 +50,20 @@ interface LRCLibResponse {
   syncedLyrics: string
 }
 
-async function getLyrics(getLyricsData: GetLyricsData) {
-  const { preferSyncedLyrics } = usePlayerStore.getState().settings.lyrics
-  const { songLyricsEnabled } = getServerExtensions()
+async function getLyrics(
+  getLyricsData: GetLyricsData,
+): Promise<LyricsResult | undefined> {
+  const { preferSyncedLyrics, preferWordLevelLyrics } =
+    usePlayerStore.getState().settings.lyrics
+  const { songLyricsEnabled, songLyricsV2Enabled } = getServerExtensions()
   const cacheEnabled = useAppStore.getState().pages.lyricsCacheEnabled
+  const useWordLevel = songLyricsV2Enabled && preferWordLevelLyrics
 
   const cacheKey = getLyricsCacheKey(
     getLyricsData,
     preferSyncedLyrics,
     songLyricsEnabled,
+    useWordLevel,
   )
 
   const readCache = cacheEnabled
@@ -83,6 +93,7 @@ async function getLyrics(getLyricsData: GetLyricsData) {
         method: 'GET',
         query: {
           id: getLyricsData.id,
+          ...(useWordLevel ? { enhanced: 'true' } : {}),
         },
       },
     )
@@ -91,10 +102,16 @@ async function getLyrics(getLyricsData: GetLyricsData) {
       const { structuredLyrics } = response.data.lyricsList
 
       if (structuredLyrics && structuredLyrics.length > 0) {
-        const syncedLyrics = structuredLyrics.find((lyrics) => lyrics.synced)
+        const primary = pickPrimaryStructuredLyric(structuredLyrics)
+        const syncedLyrics = primary?.synced
+          ? primary
+          : structuredLyrics.find((l) => l.synced)
 
         if (syncedLyrics) {
-          const serverSyncedLyrics = osStructuredLyricsToILyric(syncedLyrics)
+          const serverSyncedLyrics: LyricsResult = {
+            ...osStructuredLyricsToILyric(syncedLyrics),
+            structuredLyric: syncedLyrics,
+          }
 
           writeCache(cacheKey, serverSyncedLyrics)
 
@@ -240,6 +257,7 @@ function getLyricsCacheKey(
   getLyricsData: GetLyricsData,
   preferSyncedLyrics: boolean,
   songLyricsEnabled?: boolean,
+  songLyricsV2Enabled?: boolean,
 ) {
   const { artist, title } = getLyricsData
 
@@ -247,6 +265,7 @@ function getLyricsCacheKey(
   const serverExtension = songLyricsEnabled ? 'internal' : 'external'
 
   const keys = ['lyrics', artist, title, type, serverExtension]
+  if (songLyricsV2Enabled) keys.push('v2')
 
   return keys.join(':')
 }

--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -132,6 +132,12 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
                   state.settings.lyrics.preferSyncedLyrics = value
                 })
               },
+              preferWordLevelLyrics: false,
+              setPreferWordLevelLyrics: (value) => {
+                set((state) => {
+                  state.settings.lyrics.preferWordLevelLyrics = value
+                })
+              },
             },
             replayGain: {
               values: {
@@ -918,6 +924,7 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
                 state.settings.colors.currentSongColorIntensity = 0.65
                 state.settings.fullscreen.autoFullscreenEnabled = false
                 state.settings.lyrics.preferSyncedLyrics = false
+                state.settings.lyrics.preferWordLevelLyrics = false
                 state.settings.replayGain.values = {
                   enabled: false,
                   type: 'track',

--- a/src/types/playerContext.ts
+++ b/src/types/playerContext.ts
@@ -104,6 +104,8 @@ interface IFullscreen {
 interface ILyrics {
   preferSyncedLyrics: boolean
   setPreferSyncedLyrics: (value: boolean) => void
+  preferWordLevelLyrics: boolean
+  setPreferWordLevelLyrics: (value: boolean) => void
 }
 
 interface LrcLib {

--- a/src/types/responses/song.ts
+++ b/src/types/responses/song.ts
@@ -24,17 +24,54 @@ export interface ILyricsList {
 }
 
 export interface IStructuredLyric {
-  displayArtist: string
-  displayTitle: string
+  displayArtist?: string
+  displayTitle?: string
   lang?: string
   offset?: number
   synced: boolean
   line: IStructuredLine[]
+  kind?: 'main' | 'translation' | 'pronunciation' | (string & {})
+  cueLine?: ICueLine[]
+  agents?: IAgent[]
 }
 
 export interface IStructuredLine {
   start?: number
   value: string
+}
+
+// OpenSubsonic v2 word-level lyric types
+
+export interface IWord {
+  start?: number
+  end?: number
+  byteStart?: number
+  byteEnd?: number
+  value: string
+}
+
+export interface ICue {
+  start?: number
+  end?: number
+  byteStart?: number
+  byteEnd?: number
+  value?: string
+  word?: IWord[]
+}
+
+export interface ICueLine {
+  index: number
+  agentId?: string
+  start?: number
+  end?: number
+  value: string
+  cue: ICue[]
+}
+
+export interface IAgent {
+  id: string
+  role: 'main' | 'voice' | 'bg' | 'group' | (string & {})
+  name?: string
 }
 
 export interface IContributor {

--- a/src/utils/byteSlice.ts
+++ b/src/utils/byteSlice.ts
@@ -1,0 +1,29 @@
+export function byteSlice(
+  value: string,
+  byteStart: number,
+  byteEnd: number,
+): string {
+  if (!value) return ''
+  if (byteStart > byteEnd) {
+    if (import.meta.env.DEV)
+      console.warn('[byteSlice] byteStart > byteEnd', { byteStart, byteEnd })
+    return ''
+  }
+  const encoded = new TextEncoder().encode(value)
+  const start = Math.max(0, byteStart)
+  const end = Math.min(encoded.length - 1, byteEnd)
+  if (start > encoded.length - 1) return ''
+  return new TextDecoder('utf-8', { fatal: false }).decode(
+    encoded.slice(start, end + 1),
+  )
+}
+
+export function byteSliceFallback(
+  cue: { value?: string; byteStart?: number; byteEnd?: number },
+  lineValue: string,
+): string {
+  if (cue.byteStart !== undefined && cue.byteEnd !== undefined) {
+    return byteSlice(lineValue, cue.byteStart, cue.byteEnd)
+  }
+  return cue.value ?? ''
+}

--- a/src/utils/servers.ts
+++ b/src/utils/servers.ts
@@ -22,7 +22,10 @@ export function getServerExtensions() {
     extensionsSupported.songLyrics &&
     extensionsSupported.songLyrics.length > 0
 
+  const songLyricsV2Enabled = !!extensionsSupported?.songLyrics?.includes(2)
+
   return {
     songLyricsEnabled,
+    songLyricsV2Enabled,
   }
 }

--- a/src/utils/wordTiming.ts
+++ b/src/utils/wordTiming.ts
@@ -64,11 +64,17 @@ const ROLE_PRIORITY: Record<string, number> = {
   group: 3,
 }
 
-export function pickPrimaryStructuredLyric(
+export function pickPrimarySyncedStructuredLyric(
   list: IStructuredLyric[] | undefined,
 ): IStructuredLyric | undefined {
   if (!list || list.length === 0) return undefined
-  return list.find((l) => l.kind === 'main') ?? list[0]
+  let firstSynced: IStructuredLyric | undefined
+  for (const l of list) {
+    if (!l.synced) continue
+    if (l.kind === 'main') return l
+    if (firstSynced === undefined) firstSynced = l
+  }
+  return firstSynced
 }
 
 export function normalizeStructuredLyric(

--- a/src/utils/wordTiming.ts
+++ b/src/utils/wordTiming.ts
@@ -1,0 +1,213 @@
+import type { IStructuredLyric } from '@/types/responses/song'
+
+export interface NormalizedAgent {
+  id: string
+  role: 'main' | 'voice' | 'bg' | 'group' | string
+  name?: string
+  displayOrder: number // 0 = main (top)
+}
+
+export interface NormalizedCue {
+  start: number // ms, offset already applied
+  end: number // ms, computed via all-or-none rule if missing
+  value: string
+  byteStart?: number
+  byteEnd?: number
+}
+
+export interface NormalizedCueLine {
+  lineIndex: number
+  key: string // e.g. "0:lead" or "0:pos0" — stable identity for rAF hook
+  agentId?: string
+  agentRole?: string
+  displayOrder: number // 0 = main row; ≥1 = secondary (reduced opacity)
+  start: number
+  end: number
+  value: string
+  cues: NormalizedCue[]
+}
+
+export interface NormalizedLine {
+  start?: number // ms, offset applied — canonical line clock
+  value: string
+  cueLines: NormalizedCueLine[] // zero or more, sorted by displayOrder
+}
+
+export interface NormalizedStructuredLyric {
+  lang?: string
+  kind: string // defaults to 'main'
+  synced: boolean
+  agents: NormalizedAgent[]
+  lines: NormalizedLine[]
+  hasWordTiming: boolean
+}
+
+const DEFAULT_CUE_DURATION_MS = 500
+const ROLE_PRIORITY: Record<string, number> = {
+  main: 0,
+  voice: 1,
+  bg: 2,
+  group: 3,
+}
+
+export function pickPrimaryStructuredLyric(
+  list: IStructuredLyric[] | undefined,
+): IStructuredLyric | undefined {
+  if (!list || list.length === 0) return undefined
+  return list.find((l) => l.kind === 'main') ?? list[0]
+}
+
+export function normalizeStructuredLyric(
+  raw: IStructuredLyric,
+): NormalizedStructuredLyric {
+  const offset = raw.offset ?? 0
+
+  // 1. Normalize agents — sort by role priority then declaration order
+  const agents: NormalizedAgent[] = (raw.agents ?? [])
+    .map((a, i) => ({ ...a, _decl: i }))
+    .sort((a, b) => {
+      const pa = ROLE_PRIORITY[a.role] ?? 4
+      const pb = ROLE_PRIORITY[b.role] ?? 4
+      return pa !== pb ? pa - pb : a._decl - b._decl
+    })
+    .map((a, displayOrder) => ({
+      id: a.id,
+      role: a.role,
+      name: a.name,
+      displayOrder,
+    }))
+
+  // 2. Build lines array with empty cueLines
+  const lines: NormalizedLine[] = raw.line.map((l) => ({
+    start: l.start != null ? l.start + offset : undefined,
+    value: l.value,
+    cueLines: [],
+  }))
+
+  // 3. Walk raw cueLines — NO dedupe, preserve all
+  const lineDisplayOrderCounters = new Map<number, number>()
+
+  for (const rawCl of raw.cueLine ?? []) {
+    const idx = rawCl.index
+
+    // Skip out-of-bounds
+    if (idx < 0 || idx >= lines.length) {
+      if (import.meta.env.DEV)
+        console.warn('[wordTiming] OOB cueLine index', idx)
+      continue
+    }
+
+    let rawCues = rawCl.cue
+    if (rawCl.cue.length > 500) {
+      if (import.meta.env.DEV)
+        console.warn('[wordTiming] cueLine.cue truncated to 500')
+      rawCues = rawCl.cue.slice(0, 500)
+    }
+
+    // Build normalised cue list
+    // Determine all-or-none state for `end`
+    const allHaveEnd = rawCues.length > 0 && rawCues.every((c) => c.end != null)
+    const noneHaveEnd = rawCues.every((c) => c.end == null)
+    if (!allHaveEnd && !noneHaveEnd && rawCues.length > 0) {
+      if (import.meta.env.DEV)
+        console.warn('[wordTiming] mixed cue.end — treating as all-missing')
+    }
+
+    const cues: NormalizedCue[] = []
+    for (let i = 0; i < rawCues.length; i++) {
+      const c = rawCues[i]
+      if (c.start == null) continue // skip untimed cues
+
+      const cueStart = c.start + offset
+
+      let cueEnd: number
+      if (allHaveEnd) {
+        cueEnd = c.end! + offset
+      } else {
+        // all-or-none: compute from next cue start
+        const nextStart = rawCues[i + 1]?.start
+        const clEnd = rawCl.end != null ? rawCl.end + offset : undefined
+        const nextLineStart = lines[idx + 1]?.start
+        cueEnd =
+          (nextStart != null ? nextStart + offset : undefined) ??
+          clEnd ??
+          nextLineStart ??
+          cueStart + DEFAULT_CUE_DURATION_MS
+      }
+
+      // Defensive byte bounds check
+      let byteStart = c.byteStart
+      let byteEnd = c.byteEnd
+      if (byteStart != null && byteEnd != null && byteStart > byteEnd) {
+        if (import.meta.env.DEV)
+          console.warn('[wordTiming] byteStart > byteEnd', {
+            byteStart,
+            byteEnd,
+          })
+        byteStart = undefined
+        byteEnd = undefined
+      }
+
+      cues.push({
+        start: cueStart,
+        end: cueEnd,
+        value: c.value ?? '',
+        byteStart,
+        byteEnd,
+      })
+    }
+
+    // Resolve agent display order
+    const matchedAgent = agents.find((a) => a.id === rawCl.agentId)
+    const posCount = lineDisplayOrderCounters.get(idx) ?? 0
+    const displayOrder = matchedAgent?.displayOrder ?? posCount
+    lineDisplayOrderCounters.set(idx, posCount + 1)
+
+    // Compute cueLine start/end
+    const clStartRaw = rawCl.start != null ? rawCl.start + offset : undefined
+    const clStart = clStartRaw ?? lines[idx].start ?? cues[0]?.start ?? 0
+    const clEndRaw = rawCl.end != null ? rawCl.end + offset : undefined
+    const clEnd =
+      clEndRaw ?? lines[idx + 1]?.start ?? cues[cues.length - 1]?.end ?? clStart
+
+    const key = `${idx}:${rawCl.agentId ?? `pos${posCount}`}`
+
+    lines[idx].cueLines.push({
+      lineIndex: idx,
+      key,
+      agentId: rawCl.agentId,
+      agentRole: matchedAgent?.role,
+      displayOrder,
+      start: clStart,
+      end: clEnd,
+      value: rawCl.value,
+      cues,
+    })
+  }
+
+  // 4. Sort each line's cueLines by displayOrder
+  for (const line of lines) {
+    line.cueLines.sort((a, b) => a.displayOrder - b.displayOrder)
+  }
+
+  // 5. Promote main-agent start as canonical line clock
+  for (const line of lines) {
+    if (line.start == null && line.cueLines.length > 0) {
+      line.start = line.cueLines[0].start
+    }
+  }
+
+  // 6. Compute hasWordTiming
+  const hasWordTiming = lines.some(
+    (l) => l.cueLines.length > 0 && l.cueLines.some((cl) => cl.cues.length > 0),
+  )
+
+  return {
+    lang: raw.lang,
+    kind: raw.kind ?? 'main',
+    synced: raw.synced,
+    agents,
+    lines,
+    hasWordTiming,
+  }
+}

--- a/src/utils/wordTiming.ts
+++ b/src/utils/wordTiming.ts
@@ -29,6 +29,8 @@ export interface NormalizedCueLine {
 
 export interface NormalizedLine {
   start?: number // ms, offset applied — canonical line clock
+  end?: number // ms, offset applied — max(cueLines[*].cues[last].end); enables overlap detection for concurrent voices
+
   value: string
   cueLines: NormalizedCueLine[] // zero or more, sorted by displayOrder
 }
@@ -213,11 +215,19 @@ export function normalizeStructuredLyric(
     line.cueLines.sort((a, b) => a.displayOrder - b.displayOrder)
   }
 
-  // 5. Promote main-agent start as canonical line clock
+  // 5. Promote main-agent start as canonical line clock; derive line end from max(cues[last].end) for overlap detection
   for (const line of lines) {
     if (line.start == null && line.cueLines.length > 0) {
       line.start = line.cueLines[0].start
     }
+    let maxEnd: number | undefined
+    for (const cl of line.cueLines) {
+      const lastCueEnd = cl.cues[cl.cues.length - 1]?.end
+      if (lastCueEnd != null && (maxEnd == null || lastCueEnd > maxEnd)) {
+        maxEnd = lastCueEnd
+      }
+    }
+    if (maxEnd != null) line.end = maxEnd
   }
 
   // 6. Compute hasWordTiming
@@ -243,15 +253,6 @@ export function normalizeStructuredLyric(
 
 function computeBreaks(lines: NormalizedLine[]): NormalizedBreak[] {
   const breaks: NormalizedBreak[] = []
-
-  const lineEnd = (line: NormalizedLine): number | undefined => {
-    let max: number | undefined
-    for (const cl of line.cueLines) {
-      const e = cl.cues[cl.cues.length - 1]?.end
-      if (e != null && (max == null || e > max)) max = e
-    }
-    return max
-  }
 
   const pushIfBreak = (
     beforeLineIndex: number,
@@ -279,14 +280,16 @@ function computeBreaks(lines: NormalizedLine[]): NormalizedBreak[] {
     pushIfBreak(0, 0, lines[0].start, 'intro')
   }
 
-  // Mid-song: between consecutive lines, using each line's natural last-cue end.
-  for (let i = 1; i < lines.length; i++) {
-    const prev = lines[i - 1]
-    const curr = lines[i]
-    if (curr.start == null) continue
-    const prevEnd = lineEnd(prev)
-    if (prevEnd == null) continue
-    pushIfBreak(i, prevEnd, curr.start, String(i))
+  // Cluster-aware: gap is measured from running-max of every earlier line's end, not just lines[i-1].end, so overlap clusters don't get false-positive breaks.
+  let runningMaxEnd: number | undefined
+  for (let i = 0; i < lines.length; i++) {
+    if (i > 0 && lines[i].start != null && runningMaxEnd != null) {
+      pushIfBreak(i, runningMaxEnd, lines[i].start as number, String(i))
+    }
+    const e = lines[i].end
+    if (e != null && (runningMaxEnd == null || e > runningMaxEnd)) {
+      runningMaxEnd = e
+    }
   }
 
   return breaks

--- a/src/utils/wordTiming.ts
+++ b/src/utils/wordTiming.ts
@@ -33,6 +33,14 @@ export interface NormalizedLine {
   cueLines: NormalizedCueLine[] // zero or more, sorted by displayOrder
 }
 
+export interface NormalizedBreak {
+  beforeLineIndex: number // line index this break precedes; 0 = intro
+  start: number // ms, offset applied
+  end: number // ms, offset applied
+  dotCount: number
+  key: string // e.g. "brk:intro" or "brk:3"
+}
+
 export interface NormalizedStructuredLyric {
   lang?: string
   kind: string // defaults to 'main'
@@ -40,9 +48,13 @@ export interface NormalizedStructuredLyric {
   agents: NormalizedAgent[]
   lines: NormalizedLine[]
   hasWordTiming: boolean
+  breaks: NormalizedBreak[]
 }
 
 const DEFAULT_CUE_DURATION_MS = 500
+const INSTRUMENTAL_BREAK_THRESHOLD_MS = 3000 // gap >= this triggers an indicator
+const MAX_BREAK_DOTS = 60 // above this, dots redistribute (>1s per dot)
+
 const ROLE_PRIORITY: Record<string, number> = {
   main: 0,
   voice: 1,
@@ -124,15 +136,26 @@ export function normalizeStructuredLyric(
       if (allHaveEnd) {
         cueEnd = c.end! + offset
       } else {
-        // all-or-none: compute from next cue start
         const nextStart = rawCues[i + 1]?.start
         const clEnd = rawCl.end != null ? rawCl.end + offset : undefined
         const nextLineStart = lines[idx + 1]?.start
-        cueEnd =
-          (nextStart != null ? nextStart + offset : undefined) ??
-          clEnd ??
-          nextLineStart ??
-          cueStart + DEFAULT_CUE_DURATION_MS
+        const defaultEnd = cueStart + DEFAULT_CUE_DURATION_MS
+        // Last cue inflates to nextLineStart ONLY when the gap is below the
+        // break threshold; otherwise it ends naturally and the break indicator
+        // fills the gap. The two conditionals share INSTRUMENTAL_BREAK_THRESHOLD_MS
+        // so they cannot disagree.
+        if (nextStart != null) {
+          cueEnd = nextStart + offset
+        } else if (clEnd != null) {
+          cueEnd = clEnd
+        } else if (
+          nextLineStart != null &&
+          nextLineStart - defaultEnd < INSTRUMENTAL_BREAK_THRESHOLD_MS
+        ) {
+          cueEnd = nextLineStart
+        } else {
+          cueEnd = defaultEnd
+        }
       }
 
       // Defensive byte bounds check
@@ -202,6 +225,11 @@ export function normalizeStructuredLyric(
     (l) => l.cueLines.length > 0 && l.cueLines.some((cl) => cl.cues.length > 0),
   )
 
+  // 7. Detect instrumental breaks (≥3s gaps). Cue-end inflation above is
+  //    capped at the same threshold, so cues[last].end is the natural end
+  //    whenever a break should be reported.
+  const breaks = computeBreaks(lines)
+
   return {
     lang: raw.lang,
     kind: raw.kind ?? 'main',
@@ -209,5 +237,57 @@ export function normalizeStructuredLyric(
     agents,
     lines,
     hasWordTiming,
+    breaks,
   }
+}
+
+function computeBreaks(lines: NormalizedLine[]): NormalizedBreak[] {
+  const breaks: NormalizedBreak[] = []
+
+  const lineEnd = (line: NormalizedLine): number | undefined => {
+    let max: number | undefined
+    for (const cl of line.cueLines) {
+      const e = cl.cues[cl.cues.length - 1]?.end
+      if (e != null && (max == null || e > max)) max = e
+    }
+    return max
+  }
+
+  const pushIfBreak = (
+    beforeLineIndex: number,
+    start: number,
+    end: number,
+    keySuffix: string,
+  ) => {
+    const gap = end - start
+    if (gap < INSTRUMENTAL_BREAK_THRESHOLD_MS) return
+    const dotCount = Math.min(
+      MAX_BREAK_DOTS,
+      Math.max(1, Math.floor(gap / 1000)),
+    )
+    breaks.push({
+      beforeLineIndex,
+      start,
+      end,
+      dotCount,
+      key: `brk:${keySuffix}`,
+    })
+  }
+
+  // Intro: from t=0 to first line's start.
+  if (lines.length > 0 && lines[0].start != null) {
+    pushIfBreak(0, 0, lines[0].start, 'intro')
+  }
+
+  // Mid-song: between consecutive lines, using each line's natural last-cue end.
+  for (let i = 1; i < lines.length; i++) {
+    const prev = lines[i - 1]
+    const curr = lines[i]
+    if (curr.start == null) continue
+    const prevEnd = lineEnd(prev)
+    if (prevEnd == null) continue
+    pushIfBreak(i, prevEnd, curr.start, String(i))
+  }
+
+  return breaks
 }


### PR DESCRIPTION
## Background

OpenSubsonic has released a [v2 update to the songLyrics extension](https://opensubsonic.netlify.app/docs/endpoints/getlyricsbysongid/), which supports word-level lyric timing and other features. ~~At least [one opensubsonic implementation (navidrome) has a v2 API implementation in development](https://github.com/navidrome/navidrome/pull/5076).~~ Songlyrics v2 has shipped with Navidrome 0.63. 

## Implementation

* Adds shapes for the OS v2 response
* Adds a toggle for word-level lyrics (forces synced lyrics on)
* Adds word-level timing to the lyrics view
  * Theme primary color is used to highlight active word for the main singer
  * Gradient wipe moves across the active word for its duration
  * Each additional singer gets a 45-degree RGB-rotated color based off the theme primary color
  * Already spoken words are dimmed as playback progresses through the active line
  * Clicking on a word seeks to the start time of the word
  * Pauses between lines longer than 3s now have a timing indicator (1 dot = 1 second)


<img width="1186" height="745" alt="image" src="https://github.com/user-attachments/assets/cffe04e8-5a92-40f8-b8ec-294fe97e28a1" />


## Notes

This PR description is entirely human-authored, but the code for this change was written by Claude Opus. As part of development, I manually tested changes, reviewed the changeset for sanity, and trimmed comments for concision.

The cypress tests, admittedly, I did not run or look closely at.

I apologize if this PR's scope is too large and am happy to split it up if you prefer.

~~I'm not aware of any subsonic server implementations currently supporting the v2 extension, but I used [a dev branch of Navidrome which you can find here](https://github.com/navidrome/navidrome/pull/5076).~~ Songlyrics v2 has shipped with Navidrome 0.63. A lyricsfile which tests out the multiple concurrent singers features can be found attached.

[milet - Anytime Anywhere - 01 - Anytime Anywhere.zip](https://github.com/user-attachments/files/28825828/milet.-.Anytime.Anywhere.-.01.-.Anytime.Anywhere.zip)

I also use the dark theme, for which the theme primary color (green) contrasts well with the dim/out-of-focus color (gray) that is used for already-sung lyrics. Other themes choose similar colors for the two, so the gradient wipe isn't visible. This PR is already big enough so I didn't try to fix this, but it might be worth it to define and pick a color for this purpose in the other themes.