### PR TITLE
feat: Add mac dock menu support

### DIFF
--- a/electron/main/core/dockMenu.ts
+++ b/electron/main/core/dockMenu.ts
@@ -1,0 +1,36 @@
+import { platform } from '@electron-toolkit/utils'
+import { app, Menu } from 'electron'
+import { getMacOsMediaIcon } from './macMedia'
+import { sendPlayerEvents } from './playerEvents'
+import { playerState } from './playerState'
+
+export function updateDockMenu() {
+  if (!platform.isMacOS || !app.dock) return
+
+  const { isPlaying, hasPrevious, hasNext, hasSonglist } = playerState.value()
+
+  const dockMenu = Menu.buildFromTemplate([
+    {
+      label: isPlaying ? 'Pause' : 'Play',
+      enabled: hasSonglist,
+      icon: getMacOsMediaIcon(isPlaying ? 'pause' : 'play'),
+      click: () => sendPlayerEvents('togglePlayPause'),
+    },
+    { type: 'separator' },
+    {
+      label: 'Next',
+      enabled: hasNext,
+      icon: getMacOsMediaIcon('next'),
+      click: () => sendPlayerEvents('skipForward'),
+    },
+    {
+      label: 'Previous',
+      enabled: hasPrevious,
+      icon: getMacOsMediaIcon('previous'),
+      click: () => sendPlayerEvents('skipBackwards'),
+    },
+    { type: 'separator' },
+  ])
+
+  app.dock.setMenu(dockMenu)
+}

--- a/electron/main/core/events.ts
+++ b/electron/main/core/events.ts
@@ -7,6 +7,7 @@ import {
 } from '../../preload/types'
 import { isQuitting } from '../index'
 import { tray, updateTray } from '../tray'
+import { updateDockMenu } from './dockMenu'
 import { colorsState } from './colors'
 import {
   clearDiscordRpcActivity,
@@ -28,6 +29,7 @@ export function setupEvents(window: BrowserWindow | null) {
   window.on('show', () => {
     setTaskbarButtons()
     updateTray()
+    updateDockMenu()
   })
 
   window.on('hide', () => {
@@ -161,6 +163,7 @@ export function setupIpcEvents(window: BrowserWindow | null) {
       setTimeout(() => {
         setTaskbarButtons()
         updateTray()
+        updateDockMenu()
       }, 150)
     },
   )

--- a/electron/main/window.ts
+++ b/electron/main/window.ts
@@ -9,6 +9,8 @@ import { appIcon } from './core/icon'
 import { titleBarOverlay } from './core/titleBarOverlay'
 import { setUpdaterWindow } from './core/updater'
 import { StatefulBrowserWindow } from './core/windowPosition'
+import { updateDockMenu } from './core/dockMenu'
+import { playerState } from './core/playerState'
 import { createTray } from './tray'
 
 export let mainWindow: BrowserWindow | null = null
@@ -40,7 +42,11 @@ export function createWindow(): void {
     },
   })
 
+  // set initial state
+  playerState.setAll({ isPlaying: false, hasSonglist: false, hasPrevious: false, hasNext: false })
+
   createTray()
+  updateDockMenu()
   setupEvents(mainWindow)
   setupIpcEvents(mainWindow)
   setupDownloads(mainWindow)


### PR DESCRIPTION
Adds Play, Next and Previous buttons to the Mac dock, available by right-clicking on the Aonsoku dock icon.