### PR TITLE
feat: Support back/fwd swipe and mouse buttons to navigate

### DIFF
--- a/src/app/hooks/use-navigation-history.tsx
+++ b/src/app/hooks/use-navigation-history.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useNavigationType } from 'react-router-dom'
+import { MouseButton } from '@/utils/browser'
+import { isMacOS } from '@/utils/desktop'
+
+const SWIPE_THRESHOLD = 60  // minimum deltaX to count as a navigation gesture
+const SWIPE_COOLDOWN = 500  // ms before another swipe can fire
 
 const useNavigationHistory = () => {
   const navigationType = useNavigationType()
@@ -34,6 +39,51 @@ const useNavigationHistory = () => {
   const goForward = () => {
     if (canGoForward) navigate(1)
   }
+
+  // Mac only: Intercept mouse back/forward buttons (3/4) for in-app navigation.
+  // Reads window.history.state directly to avoid stale canGoBack/canGoForward closures.
+  useEffect(() => {
+    if (!isMacOS) return
+
+    const handleMouseButtons = (e: MouseEvent) => {
+      if (e.button === MouseButton.Back) {
+        e.preventDefault()
+        if (window.history.state?.idx > 0) navigate(-1)
+      } else if (e.button === MouseButton.Forward) {
+        e.preventDefault()
+        if (window.history.state?.idx < window.history.length - 1) navigate(1)
+      }
+    }
+
+    window.addEventListener('mousedown', handleMouseButtons)
+    return () => window.removeEventListener('mousedown', handleMouseButtons)
+  }, [navigate])
+
+  // Mac only: two-finger swipe gesture for in-app navigation.
+  // The wheel event fires when the trackpad produces horizontal overscroll (no
+  // scrollable content to consume deltaX), which is the back/forward gesture.
+  // A cooldown prevents repeated firings from a single swipe.
+  useEffect(() => {
+    if (!isMacOS) return
+
+    let lastFired = 0
+
+    const handleWheel = (e: WheelEvent) => {
+      const now = Date.now()
+      const isHorizontalDominant = Math.abs(e.deltaX) > Math.abs(e.deltaY)
+
+      if (!isHorizontalDominant || Math.abs(e.deltaX) < SWIPE_THRESHOLD) return
+      if (now - lastFired < SWIPE_COOLDOWN) return
+
+      lastFired = now
+
+      if (e.deltaX < 0 && window.history.state?.idx > 0) navigate(-1)
+      if (e.deltaX > 0 && window.history.state?.idx < window.history.length - 1) navigate(1)
+    }
+
+    window.addEventListener('wheel', handleWheel, { passive: true })
+    return () => window.removeEventListener('wheel', handleWheel)
+  }, [navigate])
 
   return { canGoBack, canGoForward, goBack, goForward }
 }

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -8,6 +8,8 @@ export enum MouseButton {
   Left = 0,
   Middle = 1,
   Right = 2,
+  Back = 3,
+  Forward = 4,
 }
 
 export const isChromeOrFirefox = ['Blink', 'Gecko'].includes(engineName)


### PR DESCRIPTION
Supports both Windows (untested), and macOS (tested) methods for navigating back and forward in the history.

Sadly, Electron's BrowserWindow swipe event only seems to fire on three-finger gestures and is broken as of Electron > 3, so two-finger gestures have to be handled ~jankily~manually.