### PR TITLE
Fix shuffle queue generation when enabled during playback

### DIFF
--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -506,9 +506,13 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
                   state.playerState.isShuffleActive = false
                 })
               } else {
-                const { currentList, currentSongIndex } = get().songlist
-                const songListToShuffle = currentList.slice(currentSongIndex)
-                const shuffledList = shuffleSongList(songListToShuffle, 0)
+                const { originalList, currentSong } = get().songlist
+
+                const currentSongIndex = originalList.findIndex(
+                  (song) => song.id === currentSong.id,
+                )
+
+                const shuffledList = shuffleSongList(originalList, currentSongIndex)
 
                 set((state) => {
                   state.songlist.shuffledList = shuffledList


### PR DESCRIPTION
## Summary

This PR fixes an issue where enabling **Shuffle** while playing an album or playlist near its end generated an incomplete queue.

Instead of shuffling the entire playlist, the player only shuffled the remaining tracks from the current position.

## Problem

The shuffle logic was based on the remaining portion of the current queue:

```ts
const songListToShuffle = currentList.slice(currentSongIndex)
```

Because of this, all tracks played before the current one were excluded from the new shuffled queue.

### Original playlist

> Current song: **Track 4**

```
┌──────────────────────┐
│ Album                │
├──────────────────────┤
│ 1. Track A           │
│ 2. Track B           │
│ 3. Track C           │
│ ▶ 4. Track D         │
│ 5. Track E           │
└──────────────────────┘
```

### Before the fix

Only the remaining tracks were shuffled.

```
┌──────────────────────┐
│ Shuffle Queue        │
├──────────────────────┤
│ ▶ Track D            │
│   Track E            │
└──────────────────────┘
```

Tracks **A**, **B** and **C** were missing from the queue.

### After the fix

Shuffle is now generated from the original playlist while keeping the currently playing track as the first item.

```
┌──────────────────────┐
│ Shuffle Queue        │
├──────────────────────┤
│ ▶ Track D            │
│   Track B            │
│   Track E            │
│   Track A            │
│   Track C            │
└──────────────────────┘
```

The current track is preserved, while every other track is shuffled.

## Technical changes

The shuffle logic now:

- Uses `originalList` instead of the remaining portion of `currentList`.
- Locates the current song within the original queue using its ID.
- Preserves the current song as the first track.
- Shuffles all remaining tracks.

## Benefits

- Fixes queue truncation when enabling shuffle during playback.
- Preserves every track in the original playlist.
- Matches the expected behavior of modern music players such as Spotify and Apple Music.