### PR TITLE
fix: unlock shuffle toggle after enabling it

### DIFF
--- a/src/app/components/actions.tsx
+++ b/src/app/components/actions.tsx
@@ -54,7 +54,7 @@ function Button({
           ? 'hover:scale-105 mr-2'
           : 'hover:bg-foreground/20',
         className,
-        isActive && 'pointer-events-none text-primary action-button-active',
+        isActive && 'text-primary action-button-active',
       )}
       variant={buttonStyle === 'primary' ? 'default' : 'ghost'}
       {...props}


### PR DESCRIPTION
I have noticed when I press the shuffle album button it shuffles my media but I can not click it again to unlock it to play in sequential order.

Summary
- The shared Actions.Button's active-state class included pointer-events-none, so once the album/playlist/artist shuffle button turned "active" it could never be clicked again. To turn shuffle back off, you had to use the bottom activity bar.
- Removed pointer-events-none from the active-state styling, keeping only the visual highlight (text-primary action-button-active), so the button remains clickable and can toggle shuffle off.

Test plan
- [x] Open an album with 2+ songs, click Shuffle, confirm it plays shuffled and the button highlights.
- [x] Click Shuffle again, confirm shuffle turns off and playback continues in original order.
- [x] Repeat for a playlist and an artist page (same shared button/behavior).
- [x] Confirm the playbar's own shuffle toggle still behaves the same as before.
