### PR TITLE
feat(player): add keyboard shortcut to toggle fullscreen mode

### DIFF
--- a/flatpak/io.github.victoralvesf.aonsoku.metainfo.xml
+++ b/flatpak/io.github.victoralvesf.aonsoku.metainfo.xml
@@ -47,6 +47,32 @@
   </screenshots>
 
   <releases>
+    <release version="0.15.0" date="2026-07-12">
+      <url type="details">https://github.com/victoralvesf/aonsoku/releases/tag/v0.15.0</url>
+      <description>
+        <p>New Features</p>
+        <ul>
+          <li>Tables: Added tooltips showing song title, artist, and album name.</li>
+          <li>New Settings: Added an option to enable/disable home page carousel auto-scroll.</li>
+          <li>Automatic CJK Script Detection: Lyrics in Chinese, Japanese, or Korean now render with Noto Sans for improved readability.</li>
+          <li>Hide Features: Added new options in content settings to hide specific features across the whole app.</li>
+          <li>KDE Window Controls: Added new window control icons for KDE.</li>
+          <li>Local Cache Control: Added cache controls and a clear button to app content settings.</li>
+          <li>Radio Metadata: Added Icecast radio metadata support.</li>
+          <li>Localization: Added support for Finnish, Swiss German, Hungarian, and Tamil. Also improved support for existing languages.</li>
+          <li>New Themes: Added Everforest Dark, Vesper, Mirage, and Arduino Light themes.</li>
+          <li>NixOS Support: Upgraded pnpm from v9 to v11, since pnpm 9 has reached end-of-life and was slated for removal from nixpkgs.</li>
+          <li>macOS Dock: Added dock support with play, pause, next, and previous buttons.</li>
+          <li>macOS Trackpad: Added support for back/forward navigation via trackpad gestures.</li>
+        </ul>
+        <p>Fixes</p>
+        <ul>
+          <li>ALAC Support: Enforced ALAC playback when needed, using transcoding.</li>
+          <li>Discord RPC: Fixed RPC not updating activity when seeking or when loop mode was enabled.</li>
+          <li>Docker Variables: Ensured Docker environment variables are always applied.</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.14.0" date="2026-04-02">
       <url type="details">https://github.com/victoralvesf/aonsoku/releases/tag/v0.14.0</url>
       <description>

--- a/src/app/components/player/player.tsx
+++ b/src/app/components/player/player.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
 import { getSongStreamUrl } from '@/api/httpClient'
 import { getProxyURL } from '@/api/podcastClient'
 import { MiniPlayerButton } from '@/app/components/mini-player/button'
@@ -9,6 +10,7 @@ import { useAppMediaCache, useAppStore } from '@/store/app.store'
 import {
   getVolume,
   usePlayerActions,
+  usePlayerFullscreen,
   usePlayerIsPlaying,
   usePlayerLoop,
   usePlayerMediaType,
@@ -66,6 +68,7 @@ export function Player() {
     usePlayerSonglist()
   const isPlaying = usePlayerIsPlaying()
   const { isSong, isRadio, isPodcast } = usePlayerMediaType()
+  const { toggleFullscreen } = usePlayerFullscreen()
   const loopState = usePlayerLoop()
   const audioPlayerRef = usePlayerRef()
   const currentPlaybackRate = usePlayerStore().playerState.currentPlaybackRate
@@ -75,6 +78,17 @@ export function Player() {
   const song = currentList[currentSongIndex]
   const radio = radioList[currentSongIndex]
   const podcast = podcastList[currentSongIndex]
+
+  useHotkeys(
+    'q',
+    () => {
+      if (isSong && song) toggleFullscreen()
+    },
+    {
+      enableOnFormTags: false,
+    },
+    [isSong, song, toggleFullscreen],
+  )
 
   const mediaCacheEnabled = useAppMediaCache()
   const songId = song?.id

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -575,7 +575,8 @@
       "previous": "Skip to previous",
       "next": "Skip to next",
       "raiseVolume": "Raise volume",
-      "lowerVolume": "Lower volume"
+      "lowerVolume": "Lower volume",
+      "toggleFullscreen": "Toggle fullscreen"
     },
     "navigation": {
       "label": "Navigation"

--- a/src/shortcuts/index.ts
+++ b/src/shortcuts/index.ts
@@ -44,6 +44,10 @@ const playbackShortcuts: IShortcut[] = [
     label: 'shortcuts.playback.lowerVolume',
     shortcuts: [META_KEY, '↓'],
   },
+  {
+    label: 'shortcuts.playback.toggleFullscreen',
+    shortcuts: ['Q'],
+  },
 ]
 
 const navigationShortcuts: IShortcut[] = [

--- a/src/store/player.store.ts
+++ b/src/store/player.store.ts
@@ -76,6 +76,11 @@ export const usePlayerStore = createWithEqualityFn<IPlayerContext>()(
                 state.fullscreen.isFullscreen = value
               })
             },
+            toggleFullscreen: () => {
+              set((state) => {
+                state.fullscreen.isFullscreen = !state.fullscreen.isFullscreen
+              })
+            },
             reset: () => {
               set((state) => {
                 state.fullscreen.isFullscreen = false


### PR DESCRIPTION
## Summary
Adds a keyboard shortcut (`Q`) to toggle player fullscreen mode, mirroring
the same behavior as the existing click-based expand button. Similar to
the fullscreen toggle shortcut in YouTube Music.

## Changes
- `player.store.ts`: new `toggleFullscreen` action in the fullscreen slice
- `player.tsx`: hotkey binding via `react-hotkeys-hook`, guarded by the
  same `isSong && song` condition used by the existing expand button
- `shortcuts/index.ts`: registers the shortcut in the shortcuts dialog
  (`Cmd/Ctrl + /`)
- `en.json`: translation key for the new shortcut label

## How to test
1. Play any song
2. Press `Q` — player should enter fullscreen
3. Press `Q` again — should exit fullscreen
4. Confirm `Q` does nothing when no song is playing, or when focus is on
   a text input

## Known limitations
- If fullscreen is active and the user switches to a podcast or radio
  (where `isSong` becomes false), fullscreen state does not auto-close.
  This matches pre-existing behavior of the click button and was not
  introduced by this change.

## Notes
- Did not modify translation files other than `en.json`, per the
  project's Weblate-based translation workflow mentioned in the README.
- Pre-existing test failures on `main` (5 of 7 Cypress specs) were
  verified to be unrelated to this change — same failures occur on
  `main` without this branch applied.