### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,15 +246,15 @@ This project uses [Weblate](https://hosted.weblate.org/projects/aonsoku/) for tr
 <picture>
   <source
     media="(prefers-color-scheme: dark)"
-    srcset="https://api.star-history.com/svg?repos=victoralvesf/aonsoku&type=Date&theme=dark"
+    srcset="https://star-history.dera.page/svg?repos=victoralvesf/aonsoku&type=Date&theme=dark"
   />
   <source
     media="(prefers-color-scheme: light)"
-    srcset="https://api.star-history.com/svg?repos=victoralvesf/aonsoku&type=Date"
+    srcset="https://star-history.dera.page/svg?repos=victoralvesf/aonsoku&type=Date"
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=victoralvesf/aonsoku&type=Date"
+    src="https://star-history.dera.page/svg?repos=victoralvesf/aonsoku&type=Date"
   />
 </picture>
 


### PR DESCRIPTION
The star history chart on the README is currently broken. This updates it to use a working data source so the chart renders correctly again.