### PR TITLE
feat: add right-click context menu to queue

### DIFF
--- a/src/app/components/fullscreen/queue.tsx
+++ b/src/app/components/fullscreen/queue.tsx
@@ -7,6 +7,8 @@ import {
   usePlayerSonglist,
 } from '@/store/player.store'
 import { QueueItem } from './queue-item'
+import { ContextMenuProvider } from '@/app/components/table/context-menu'
+import { QueueMenuOptions } from '@/app/components/queue/menu-options'
 
 export function FullscreenSongQueue() {
   const { setSongList } = usePlayerActions()
@@ -58,24 +60,28 @@ export function FullscreenSongQueue() {
         {virtualizer.getVirtualItems().map((virtualRow) => {
           const entry = currentList[virtualRow.index]
           return (
-            <QueueItem
+            <ContextMenuProvider
               key={entry.id}
-              data-row-index={virtualRow.index}
-              data-state={currentSong.id === entry.id ? 'active' : 'inactive'}
-              index={virtualRow.index}
-              song={entry}
-              isPlaying={currentSong.id === entry.id && isPlaying}
-              onClick={() => {
-                if (currentSong.id !== entry.id) {
-                  setSongList(currentList, virtualRow.index)
-                }
-              }}
-              style={{
-                position: 'absolute',
-                top: 0,
-                transform: `translateY(${virtualRow.start}px)`,
-              }}
-            />
+              options={<QueueMenuOptions song={entry} />}
+            >
+              <QueueItem
+                data-row-index={virtualRow.index}
+                data-state={currentSong.id === entry.id ? 'active' : 'inactive'}
+                index={virtualRow.index}
+                song={entry}
+                isPlaying={currentSong.id === entry.id && isPlaying}
+                onClick={() => {
+                  if (currentSong.id !== entry.id) {
+                    setSongList(currentList, virtualRow.index)
+                  }
+                }}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              />
+            </ContextMenuProvider>
           )
         })}
       </div>

--- a/src/app/components/options/buttons.tsx
+++ b/src/app/components/options/buttons.tsx
@@ -143,6 +143,22 @@ function RemoveFromPlaylist({
   )
 }
 
+function RemoveFromQueue({
+  variant = 'dropdown',
+  ...props
+}: DropdownMenuItemProps) {
+  const { t } = useTranslation()
+
+  return (
+    <MenuItemFactory
+      variant={variant}
+      icon={<Trash className="mr-2 h-4 w-4 fill-red-300 text-red-500" />}
+      label={t('queue.removeSong')}
+      {...props}
+    />
+  )
+}
+
 function SongInfo({ variant = 'dropdown', ...props }: DropdownMenuItemProps) {
   const { t } = useTranslation()
 
@@ -204,6 +220,7 @@ export const OptionsButtons = {
   EditPlaylist,
   RemovePlaylist,
   RemoveFromPlaylist,
+  RemoveFromQueue,
   SongInfo,
   MarkAsPlayed,
   GotoPodcast,

--- a/src/app/components/queue/menu-options.tsx
+++ b/src/app/components/queue/menu-options.tsx
@@ -1,0 +1,41 @@
+import { OptionsButtons } from '@/app/components/options/buttons'
+import { ContextMenuSeparator } from '@/app/components/ui/context-menu'
+import { AddToPlaylistSubMenu } from '@/app/components/song/add-to-playlist'
+import { useOptions } from '@/app/hooks/use-options'
+import { useAppStore } from '@/store/app.store'
+import { usePlayerActions } from '@/store/player.store'
+import { ISong } from '@/types/responses/song'
+
+interface QueueMenuOptionsProps {
+  song: ISong
+}
+
+export function QueueMenuOptions({ song }: QueueMenuOptionsProps) {
+  const { createNewPlaylist, addToPlaylist } = useOptions()
+  const hidePlaylistsSection = useAppStore().pages.hidePlaylistsSection
+  const { removeSongFromQueue } = usePlayerActions()
+
+  return (
+    <>
+      {!hidePlaylistsSection && (
+        <>
+          <OptionsButtons.AddToPlaylistOption variant="context">
+            <AddToPlaylistSubMenu
+              type="context"
+              newPlaylistFn={() => createNewPlaylist(song.title, song.id)}
+              addToPlaylistFn={(id) => addToPlaylist(id, song.id)}
+            />
+          </OptionsButtons.AddToPlaylistOption>
+          <ContextMenuSeparator />
+        </>
+      )}
+      <OptionsButtons.RemoveFromQueue
+        variant="context"
+        onClick={(e) => {
+          e.stopPropagation()
+          removeSongFromQueue(song.id)
+        }}
+      />
+    </>
+  )
+}

--- a/src/app/components/queue/song-list.tsx
+++ b/src/app/components/queue/song-list.tsx
@@ -96,7 +96,7 @@ export function QueueSongList() {
           scrollToIndex={true}
           currentSongIndex={currentSongIndex}
           allowRowSelection={false}
-          showContextMenu={false}
+          showContextMenu={true}
           pageType="queue"
         />
       </div>

--- a/src/app/components/ui/data-table-list.tsx
+++ b/src/app/components/ui/data-table-list.tsx
@@ -25,6 +25,7 @@ import {
 import { isMacOs } from 'react-device-detect'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { SongMenuOptions } from '@/app/components/song/menu-options'
+import { QueueMenuOptions } from '@/app/components/queue/menu-options'
 import { SelectedSongsMenuOptions } from '@/app/components/song/selected-options'
 import { ColumnFilter } from '@/types/columnFilter'
 import { ColumnDefType } from '@/types/react-table/columnDef'
@@ -184,6 +185,10 @@ export function DataTableList<TData, TValue>({
     (row: Row<TData>) => {
       if (!showContextMenu) return undefined
 
+      if (pageType === 'queue') {
+        return <QueueMenuOptions song={row.original as ISong} />
+      }
+
       if (dataType === 'song') {
         if (table.getIsSomeRowsSelected() || table.getIsAllRowsSelected()) {
           return (
@@ -204,7 +209,7 @@ export function DataTableList<TData, TValue>({
 
       return undefined
     },
-    [dataType, showContextMenu, table],
+    [dataType, showContextMenu, table, pageType],
   )
 
   const handleLeftClick = useCallback(

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -557,7 +557,8 @@
     "title": "Queue",
     "clear": "Clear queue",
     "close": "Close queue",
-    "open": "Open queue"
+    "open": "Open queue",
+    "removeSong": "Remove from queue"
   },
   "shortcuts": {
     "modal": {


### PR DESCRIPTION
# Summary
At the moment, the queue functionality is relatively limited. A fully featured queue would likely include features like reorganizing, add to playlist, etc. However, fully implementing these things would be a large undertaking.
The pragmatic approach is probably to first add a basic context menu to the queue, accessible via right-click. This can be done mostly by reusing the existing context menu options used across the project. Moreover, it will provide a scaffold which should reduce the complexity of adding other queue features in the future.

This change was carried out:
A basic context menu was added to the queue drawer and to the fullscreen queue. At the moment it consists of an 'Add to playlist' button and a 'Remove from queue' button, and can be accessed by right-clicking on a song in the queue. It should be easily extensible for later features as needed.
# Implementation
- A new `removeFromQueue` button was added to `src/app/components/options/buttons.tsx`
- A new file `src/app/components/queue/menu-options.tsx` was created, containing the component `QueueMenuOptions`
- In `src/app/components/fullscreen/queue.tsx` the rows were wrapped in `ContextMenuProvider` and passed `QueueMenuOptions`
- Context menu was enabled for `src/app/components/queue/song-list.tsx`
- `QueueMenuOptions` added to `src/app/components/ui/data-table-list.tsx`
- English locale information in `src/i18n/locales/en.json` was updated